### PR TITLE
Extend JIRA issue configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,6 @@ System pass it in payload to registrar with aim to be used as "identifier" of as
 
 Currently, todo-registrar supports the following issue trackers:
 
-| Issue Tracker                                   | Description              |
-|-------------------------------------------------|--------------------------|
-| [Jira](https://www.atlassian.com/software/jira) | Supported via API tokens |
+| Issue Tracker                                   | Description                                                                                 |
+|-------------------------------------------------|---------------------------------------------------------------------------------------------|
+| [Jira](https://www.atlassian.com/software/jira) | Supported via API tokens. See [description of configuration](docs/registrar/jira/config.md) |

--- a/docs/registrar/jira/config.md
+++ b/docs/registrar/jira/config.md
@@ -9,6 +9,7 @@ $jiraConfig = [
                                                     // when "assignee-suffix" was not used with tag.
         'components' => ['a-component'],            // list of components which will be set to issue 
         'labels' => ['a-label'],                    // list of labels which will be set to issue
+        'priority' => 'string',                     // priority of issue
         'tagPrefix' => 'tag-',                      // prefix which will be added to tag when "addTagToLabels=true"
         'type' => 'Bug',                            // type of issue
     ],

--- a/docs/registrar/jira/config.md
+++ b/docs/registrar/jira/config.md
@@ -1,0 +1,28 @@
+# Configuration of JIRA-registrar
+
+Description of keys:
+```php
+$jiraConfig = [
+    'issue' => [
+        'addTagToLabels' => true,                   // add detected tag into list of issue labels or not
+        'assignee' => 'string'                      // identifier of JIRA-user, which will be assigned to ticket
+                                                    // when "assignee-suffix" was not used with tag.
+        'components' => ['a-component'],            // list of components which will be set to issue 
+        'labels' => ['a-label'],                    // list of labels which will be set to issue
+        'tagPrefix' => 'tag-',                      // prefix which will be added to tag when "addTagToLabels=true"
+        'type' => 'Bug',                            // type of issue
+    ],
+    'projectKey' => 'string',                       // key-name of project
+    'service' => [
+        'host' => 'string',                         // host of JIRA-server
+        'personalAccessToken' => 'string',          // personal access-token
+        'tokenBasedAuth' => true,
+        
+        // JIRA username and password can be used as alternative for authentication on JIRA-server.
+        // So, previous option "tokenBasedAuth" must be set to "false".
+        //
+        // 'jiraUser' => 'string',
+        // 'jiraPassword' => 'string',
+    ]
+];
+```

--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeliot\TodoRegistrar\Exception;
+
+final class InvalidConfigException extends \InvalidArgumentException
+{
+}

--- a/src/Service/Registrar/JIRA/IssueConfig.php
+++ b/src/Service/Registrar/JIRA/IssueConfig.php
@@ -7,6 +7,7 @@ namespace Aeliot\TodoRegistrar\Service\Registrar\JIRA;
 class IssueConfig
 {
     private bool $addTagToLabels;
+    private ?string $assignee;
     /**
      * @var string[]
      */
@@ -24,18 +25,31 @@ class IssueConfig
      */
     public function __construct(array $config)
     {
-        $issue = $config['issue'];
-        $this->addTagToLabels = $issue['addTagToLabels'] ?? false;
-        $this->components = (array) ($issue['components'] ?? []);
+        $issueDefaults = [
+            'addTagToLabels' => false,
+            'assignee' => null,
+            'components' => [],
+            'labels' => [],
+            'tagPrefix' => '',
+        ];
+        $issue = $config['issue'] + $issueDefaults;
+        $this->addTagToLabels = (bool) $issue['addTagToLabels'];
+        $this->assignee = $issue['assignee'];
+        $this->components = (array) $issue['components'];
         $this->issueType = $issue['type'];
-        $this->labels = (array) ($issue['labels'] ?? []);
+        $this->labels = (array) $issue['labels'];
         $this->projectKey = $config['projectKey'];
-        $this->tagPrefix = $issue['tagPrefix'] ?? '';
+        $this->tagPrefix = $issue['tagPrefix'];
     }
 
     public function isAddTagToLabels(): bool
     {
         return $this->addTagToLabels;
+    }
+
+    public function getAssignee(): ?string
+    {
+        return $this->assignee;
     }
 
     /**

--- a/src/Service/Registrar/JIRA/IssueConfig.php
+++ b/src/Service/Registrar/JIRA/IssueConfig.php
@@ -17,6 +17,7 @@ class IssueConfig
      * @var string[]
      */
     private array $labels;
+    private ?string $priority;
     private string $projectKey;
     private string $tagPrefix;
 
@@ -30,6 +31,7 @@ class IssueConfig
             'assignee' => null,
             'components' => [],
             'labels' => [],
+            'priority' => null,
             'tagPrefix' => '',
         ];
         $issue = $config['issue'] + $issueDefaults;
@@ -38,6 +40,7 @@ class IssueConfig
         $this->components = (array) $issue['components'];
         $this->issueType = $issue['type'];
         $this->labels = (array) $issue['labels'];
+        $this->priority = $issue['priority'];
         $this->projectKey = $config['projectKey'];
         $this->tagPrefix = $issue['tagPrefix'];
     }
@@ -71,6 +74,11 @@ class IssueConfig
     public function getLabels(): array
     {
         return $this->labels;
+    }
+
+    public function getPriority(): ?string
+    {
+        return $this->priority;
     }
 
     public function getProjectKey(): string

--- a/src/Service/Registrar/JIRA/IssueConfig.php
+++ b/src/Service/Registrar/JIRA/IssueConfig.php
@@ -34,14 +34,14 @@ class IssueConfig
             'priority' => null,
             'tagPrefix' => '',
         ];
-        $issue = $config['issue'] + $issueDefaults;
+        $issue = $config + $issueDefaults;
         $this->addTagToLabels = (bool) $issue['addTagToLabels'];
         $this->assignee = $issue['assignee'];
         $this->components = (array) $issue['components'];
         $this->issueType = $issue['type'];
         $this->labels = (array) $issue['labels'];
         $this->priority = $issue['priority'];
-        $this->projectKey = $config['projectKey'];
+        $this->projectKey = $issue['projectKey'];
         $this->tagPrefix = $issue['tagPrefix'];
     }
 

--- a/src/Service/Registrar/JIRA/IssueConfig.php
+++ b/src/Service/Registrar/JIRA/IssueConfig.php
@@ -26,23 +26,16 @@ class IssueConfig
      */
     public function __construct(array $config)
     {
-        $issueDefaults = [
-            'addTagToLabels' => false,
-            'assignee' => null,
-            'components' => [],
-            'labels' => [],
-            'priority' => null,
-            'tagPrefix' => '',
-        ];
-        $issue = $config + $issueDefaults;
-        $this->addTagToLabels = (bool) $issue['addTagToLabels'];
-        $this->assignee = $issue['assignee'];
-        $this->components = (array) $issue['components'];
-        $this->issueType = $issue['type'];
-        $this->labels = (array) $issue['labels'];
-        $this->priority = $issue['priority'];
-        $this->projectKey = $issue['projectKey'];
-        $this->tagPrefix = $issue['tagPrefix'];
+        $config = $this->normalizeConfig($config);
+
+        $this->addTagToLabels = $config['addTagToLabels'];
+        $this->assignee = $config['assignee'];
+        $this->components = $config['components'];
+        $this->issueType = $config['type'];
+        $this->labels = $config['labels'];
+        $this->priority = $config['priority'];
+        $this->projectKey = $config['projectKey'];
+        $this->tagPrefix = $config['tagPrefix'];
     }
 
     public function isAddTagToLabels(): bool
@@ -89,5 +82,28 @@ class IssueConfig
     public function getTagPrefix(): string
     {
         return $this->tagPrefix;
+    }
+
+    /**
+     * @param array<string,mixed> $config
+     *
+     * @return array<string,mixed>
+     */
+    public function normalizeConfig(array $config): array
+    {
+        $config += [
+            'addTagToLabels' => false,
+            'assignee' => null,
+            'components' => [],
+            'labels' => [],
+            'priority' => null,
+            'tagPrefix' => '',
+        ];
+
+        $config['addTagToLabels'] = (bool) $config['addTagToLabels'];
+        $config['components'] = (array) $config['components'];
+        $config['labels'] = (array) $config['labels'];
+
+        return $config;
     }
 }

--- a/src/Service/Registrar/JIRA/IssueFieldFactory.php
+++ b/src/Service/Registrar/JIRA/IssueFieldFactory.php
@@ -29,6 +29,11 @@ final class IssueFieldFactory
             $issueField->setAssigneeNameAsString($assignee);
         }
 
+        $priority = $this->issueConfig->getPriority();
+        if ($priority) {
+            $issueField->setPriorityNameAsString($priority);
+        }
+
         $labels = $this->issueConfig->getLabels();
         if ($this->issueConfig->isAddTagToLabels()) {
             $labels[] = strtolower(sprintf('%s%s', $this->issueConfig->getTagPrefix(), $todo->getTag()));

--- a/src/Service/Registrar/JIRA/IssueFieldFactory.php
+++ b/src/Service/Registrar/JIRA/IssueFieldFactory.php
@@ -24,7 +24,7 @@ final class IssueFieldFactory
             ->setDescription($todo->getDescription())
             ->addComponentsAsArray($this->issueConfig->getComponents());
 
-        $assignee = $todo->getAssignee();
+        $assignee = $todo->getAssignee() ?? $this->issueConfig->getAssignee();
         if ($assignee) {
             $issueField->setAssigneeNameAsString($assignee);
         }

--- a/src/Service/Registrar/JIRA/JiraRegistrarFactory.php
+++ b/src/Service/Registrar/JIRA/JiraRegistrarFactory.php
@@ -13,8 +13,9 @@ class JiraRegistrarFactory implements RegistrarFactoryInterface
 {
     public function create(array $config): RegistrarInterface
     {
+        $issueConfig = ($config['issue'] ?? []) + ['projectKey' => $config['projectKey']];
         return new JiraRegistrar(
-            new IssueFieldFactory(new IssueConfig($config)),
+            new IssueFieldFactory(new IssueConfig($issueConfig)),
             $this->createIssueService($config['service']),
         );
     }

--- a/src/Service/Tag/Detector.php
+++ b/src/Service/Tag/Detector.php
@@ -24,6 +24,6 @@ class Detector
             return null;
         }
 
-        return new TagMetadata(strtoupper($matches[2]), strlen($matches[1]), $matches[3] ?? null);
+        return new TagMetadata(strtoupper($matches[2]), strlen(rtrim($matches[1])), $matches[3] ?? null);
     }
 }

--- a/tests/Unit/Service/Comment/ExtractorTest.php
+++ b/tests/Unit/Service/Comment/ExtractorTest.php
@@ -28,19 +28,22 @@ final class ExtractorTest extends TestCase
             1,
             '// TODO single line comment',
         ];
+
         yield [
             1,
             1,
             '# TODO single line comment',
         ];
+
         yield [
             1,
             1,
-            <<<CON
+            <<<CONT
 # TODO single line comment
 #      with some extra part
-CON,
+CONT,
         ];
+
         yield [
             3,
             1,
@@ -50,6 +53,7 @@ CON,
  */
 CONT,
         ];
+
         yield [
             3,
             1,

--- a/tests/Unit/Service/Registrar/IssueConfigTest.php
+++ b/tests/Unit/Service/Registrar/IssueConfigTest.php
@@ -4,13 +4,72 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Test\Unit\Service\Registrar;
 
+use Aeliot\TodoRegistrar\Exception\InvalidConfigException;
 use Aeliot\TodoRegistrar\Service\Registrar\JIRA\IssueConfig;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(IssueConfig::class)]
 final class IssueConfigTest extends TestCase
 {
+    public static function getDataForTestIssueTypeAlias(): iterable
+    {
+        yield [
+            [
+                'projectKey' => 'any string',
+                'issueType' => 'Bug',
+            ]
+        ];
+
+        yield [
+            [
+                'projectKey' => 'any string',
+                'type' => 'Bug',
+            ]
+        ];
+    }
+
+    public static function getDataForTestThrowExceptionWhenMissedRequiredProperty(): iterable
+    {
+        $fullConfig = [
+            'projectKey' => 'any string',
+            'type' => 'any string',
+        ];
+
+        foreach (array_keys($fullConfig) as $key) {
+            $config = $fullConfig;
+            unset($config[$key]);
+            yield [$config];
+        }
+    }
+
+    #[DataProvider('getDataForTestIssueTypeAlias')]
+    public function testIssueTypeAlias(array $values): void
+    {
+        $config = new IssueConfig($values);
+        self::assertSame('Bug', $config->getIssueType());
+    }
+
+    public function testThrowExceptionWithIssueTypeDuplicatedByAlias(): void
+    {
+        $this->expectException(InvalidConfigException::class);
+        $values = [
+            'projectKey' => 'any string',
+            'type' => 'any string',
+            'issueType' => 'any string',
+        ];
+        new IssueConfig($values);
+
+    }
+
+    #[DataProvider('getDataForTestThrowExceptionWhenMissedRequiredProperty')]
+    public function testThrowExceptionWhenMissedRequiredProperty(array $values): void
+    {
+        $this->expectException(InvalidConfigException::class);
+        new IssueConfig($values);
+    }
+
     public function testValueAssigning(): void
     {
         $values = [

--- a/tests/Unit/Service/Registrar/IssueConfigTest.php
+++ b/tests/Unit/Service/Registrar/IssueConfigTest.php
@@ -18,6 +18,7 @@ final class IssueConfigTest extends TestCase
                 'addTagToLabels' => true,
                 'components' => ['Component-1', 'Component-2'],
                 'labels' => ['Label-1', 'Label-2'],
+                'priority' => 'Low',
                 'tagPrefix' => 'tag-',
                 'type' => 'Bug',
             ],
@@ -27,6 +28,7 @@ final class IssueConfigTest extends TestCase
 
         self::assertTrue($config->isAddTagToLabels());
         self::assertSame('Bug', $config->getIssueType());
+        self::assertSame('Low', $config->getPriority());
         self::assertSame('tag-', $config->getTagPrefix());
         self::assertSame(['Component-1', 'Component-2'], $config->getComponents());
         self::assertSame(['Label-1', 'Label-2'], $config->getLabels());

--- a/tests/Unit/Service/Registrar/IssueConfigTest.php
+++ b/tests/Unit/Service/Registrar/IssueConfigTest.php
@@ -14,14 +14,13 @@ final class IssueConfigTest extends TestCase
     public function testValueAssigning(): void
     {
         $values = [
-            'issue' => [
-                'addTagToLabels' => true,
-                'components' => ['Component-1', 'Component-2'],
-                'labels' => ['Label-1', 'Label-2'],
-                'priority' => 'Low',
-                'tagPrefix' => 'tag-',
-                'type' => 'Bug',
-            ],
+            'addTagToLabels' => true,
+            'components' => ['Component-1', 'Component-2'],
+            'labels' => ['Label-1', 'Label-2'],
+            'priority' => 'Low',
+            'tagPrefix' => 'tag-',
+            'type' => 'Bug',
+            // extra key added in factory
             'projectKey' => 'Todo',
         ];
         $config = new IssueConfig($values);

--- a/tests/Unit/Service/Tag/DetectorTest.php
+++ b/tests/Unit/Service/Tag/DetectorTest.php
@@ -76,25 +76,19 @@ final class DetectorTest extends TestCase
     #[DataProvider('getDataForTestAssigneeDetection')]
     public function testAssigneeDetection(string $expectedAssignee, string $line): void
     {
-        $tagMetadata = (new Detector())->getTagMetadata($line);
-        self::assertInstanceOf(TagMetadata::class, $tagMetadata);
-        self::assertSame($expectedAssignee, $tagMetadata->getAssignee());
+        self::assertSame($expectedAssignee, $this->getTagMetadata($line)->getAssignee());
     }
 
     #[DataProvider('getDataForTestAssigneeNotDetected')]
     public function testAssigneeNotDetected(string $line): void
     {
-        $tagMetadata = (new Detector())->getTagMetadata($line);
-        self::assertInstanceOf(TagMetadata::class, $tagMetadata);
-        self::assertNull($tagMetadata->getAssignee());
+        self::assertNull($this->getTagMetadata($line)->getAssignee());
     }
 
     #[DataProvider('getDataForTestTagDetection')]
     public function testTagDetection(string $expectedTag, string $line, array $tags): void
     {
-        $tagMetadata = (new Detector($tags))->getTagMetadata($line);
-        self::assertInstanceOf(TagMetadata::class, $tagMetadata);
-        self::assertSame($expectedTag, $tagMetadata->getTag());
+        self::assertSame($expectedTag, $this->getTagMetadata($line, $tags)->getTag());
     }
 
     #[DataProvider('getDataForTestTagNotDetected')]
@@ -107,7 +101,15 @@ final class DetectorTest extends TestCase
     #[DataProvider('getDataForTestTagUppercased')]
     public function testTagUppercased(string $expectedTag, string $line, array $tags): void
     {
-        $tagMetadata = (new Detector($tags))->getTagMetadata($line);
-        self::assertSame($expectedTag, $tagMetadata->getTag());
+        self::assertSame($expectedTag, $this->getTagMetadata($line, $tags)->getTag());
+    }
+
+    private function getTagMetadata(string $line, array $tags = []): TagMetadata
+    {
+        $detector = $tags ? new Detector($tags) : new Detector();
+        $tagMetadata = $detector->getTagMetadata($line);
+        self::assertInstanceOf(TagMetadata::class, $tagMetadata);
+
+        return $tagMetadata;
     }
 }

--- a/tests/Unit/Service/Tag/DetectorTest.php
+++ b/tests/Unit/Service/Tag/DetectorTest.php
@@ -43,6 +43,8 @@ final class DetectorTest extends TestCase
         yield ['TODO', ' # TODO', ['todo']];
         yield ['TODO', '* TODO', ['todo']];
         yield ['TODO', ' * TODO', ['todo']];
+        yield ['TODO', ' /* TODO', ['todo']];
+        yield ['TODO', ' /** TODO', ['todo']];
         yield ['TODO', ' TODO', ['todo']];
         yield ['TODO', 'TODO', ['todo']];
 
@@ -59,6 +61,15 @@ final class DetectorTest extends TestCase
     {
         yield ['// FIXME', ['todo']];
         yield ['// TODO', ['fixme']];
+    }
+
+    public static function getDataForTestPrefixLength(): iterable
+    {
+        // line formats
+        yield [7, '// TODO text of comment'];
+        yield [8, '// TODO: text of comment'];
+        yield [19, '// TODO@an_assignee text of comment'];
+        yield [20, '// TODO@an_assignee: text of comment'];
     }
 
     public static function getDataForTestTagUppercased(): iterable
@@ -83,6 +94,12 @@ final class DetectorTest extends TestCase
     public function testAssigneeNotDetected(string $line): void
     {
         self::assertNull($this->getTagMetadata($line)->getAssignee());
+    }
+
+    #[DataProvider('getDataForTestPrefixLength')]
+    public function testPrefixLength(int $expectedPrefixLength, string $line): void
+    {
+        self::assertSame($expectedPrefixLength, $this->getTagMetadata($line)->getPrefixLength());
     }
 
     #[DataProvider('getDataForTestTagDetection')]


### PR DESCRIPTION
## New functionality
- Add default assignee into JIRA issue config
- Add priority config of JIRA issue
- Throw exception on invalid JIRA issue config

## Fixes
- fix detection of `prefixLength` which leaded to extra spaces before injected issue key

## Chore
- update documentation