### PR TITLE
fix: use proper methods to set summary and description of JIRA issue

### DIFF
--- a/src/Dto/Comment/CommentPart.php
+++ b/src/Dto/Comment/CommentPart.php
@@ -32,7 +32,9 @@ class CommentPart
         }
 
         $prefixLength = (int) $this->tagMetadata?->getPrefixLength();
-        $lines = array_map(static fn(string $line): string => substr($line, $prefixLength), $this->lines);
+        $lines = $this->lines;
+        array_shift($lines);
+        $lines = array_map(static fn (string $line): string => substr($line, $prefixLength), $lines);
 
         return implode('', $lines);
     }

--- a/src/Service/TodoFactory.php
+++ b/src/Service/TodoFactory.php
@@ -13,8 +13,8 @@ class TodoFactory
     {
         return new Todo(
             $commentPart->getTag(),
-            $commentPart->getFirstLine(),
-            $commentPart->getContent(),
+            $commentPart->getSummary(),
+            $commentPart->getDescription(),
             $commentPart->getTagMetadata()?->getAssignee(),
         );
     }

--- a/tests/Unit/Dto/Comment/CommentPartTest.php
+++ b/tests/Unit/Dto/Comment/CommentPartTest.php
@@ -33,6 +33,55 @@ final class CommentPartTest extends TestCase
     }
 
     /**
+     * @return iterable<array{0: string, 1: array<string>, 2: int}>
+     */
+    public static function getDataForTestGetDescription(): iterable
+    {
+        yield [
+            " second line of description\n" .
+            " third line of description\n",
+            [
+                " * TODO: first line of description\n",
+                " *       second line of description\n",
+                " *       third line of description\n",
+            ],
+            8,
+        ];
+
+        yield [
+            '',
+            [
+                ' # TODO: one line of description',
+            ],
+            8,
+        ];
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: array<string>, 2: int}>
+     */
+    public static function getDataForTestGetSummary(): iterable
+    {
+        yield [
+            'first line of description',
+            [
+                " * TODO: first line of description\n",
+                " *       second line of description\n",
+                " *       third line of description\n",
+            ],
+            8,
+        ];
+
+        yield [
+            'one line of description',
+            [
+                ' # TODO: one line of description',
+            ],
+            8,
+        ];
+    }
+
+    /**
      * @return iterable<array{0: string, 1: string, 2: int, 3: array<string>}>
      */
     public static function getDataForTestInjectKey(): iterable
@@ -45,7 +94,7 @@ final class CommentPartTest extends TestCase
             [
                 " * TODO: first line of description\n",
                 " *       second line of description\n",
-            ]
+            ],
         ];
     }
 
@@ -86,6 +135,34 @@ final class CommentPartTest extends TestCase
     /**
      * @param string[] $lines
      */
+    #[DataProvider('getDataForTestGetDescription')]
+    public function testGetDescription(string $expected, array $lines, int $prefixLength): void
+    {
+        $metadata = $this->createMock(TagMetadata::class);
+        $metadata->method('getPrefixLength')->willReturn($prefixLength);
+        $commentPart = new CommentPart($metadata);
+        array_walk($lines, static fn (string $line) => $commentPart->addLine($line));
+
+        self::assertEquals($expected, $commentPart->getDescription());
+    }
+
+    /**
+     * @param string[] $lines
+     */
+    #[DataProvider('getDataForTestGetSummary')]
+    public function testGetSummary(string $expected, array $lines, int $prefixLength): void
+    {
+        $metadata = $this->createMock(TagMetadata::class);
+        $metadata->method('getPrefixLength')->willReturn($prefixLength);
+        $commentPart = new CommentPart($metadata);
+        array_walk($lines, static fn (string $line) => $commentPart->addLine($line));
+
+        self::assertEquals($expected, $commentPart->getSummary());
+    }
+
+    /**
+     * @param string[] $lines
+     */
     #[DataProvider('getDataForTestInjectKey')]
     public function testInjectKey(string $expectedContent, string $key, int $prefixLength, array $lines): void
     {
@@ -121,6 +198,7 @@ final class CommentPartTest extends TestCase
         foreach ($lines as $line) {
             $commentPart->addLine($line);
         }
+
         return $commentPart;
     }
 }

--- a/tests/Unit/Service/TodoFactoryTest.php
+++ b/tests/Unit/Service/TodoFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aeliot\TodoRegistrar\Test\Unit\Service;
+
+use Aeliot\TodoRegistrar\Dto\Comment\CommentPart;
+use Aeliot\TodoRegistrar\Dto\Tag\TagMetadata;
+use Aeliot\TodoRegistrar\Service\TodoFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TodoFactory::class)]
+final class TodoFactoryTest extends TestCase
+{
+    public function testMappingOfBaseFields(): void
+    {
+        $tagMetadata = $this->createMock(TagMetadata::class);
+        $tagMetadata->method('getAssignee')->willReturn('assignee');
+
+        $commentPart = $this->createMock(CommentPart::class);
+        $commentPart->method('getSummary')->willReturn('summary');
+        $commentPart->method('getDescription')->willReturn('description');
+        $commentPart->method('getTag')->willReturn('a-tag');
+        $commentPart->method('getTagMetadata')->willReturn($tagMetadata);
+
+        $todo = (new TodoFactory())->create($commentPart);
+
+        self::assertSame('a-tag', $todo->getTag());
+        self::assertSame('summary', $todo->getSummary());
+        self::assertSame('description', $todo->getDescription());
+        self::assertSame('assignee', $todo->getAssignee());
+    }
+
+    public function testMappingOfAssigneeWithoutTagMetadata(): void
+    {
+        $commentPart = $this->createMock(CommentPart::class);
+        $commentPart->method('getSummary')->willReturn('summary');
+        $commentPart->method('getDescription')->willReturn('description');
+        $commentPart->method('getTag')->willReturn('a-tag');
+        $commentPart->method('getTagMetadata')->willReturn(null);
+
+        $todo = (new TodoFactory())->create($commentPart);
+
+        self::assertNull($todo->getAssignee());
+    }
+}


### PR DESCRIPTION
Remove prefixes of comments. So, parts of multi-line comment will be used correctly.

Income:
```php
/**
 * TODO: first line of description
 *       second line of description
 *       third line of description
 */
```

Summary:
```
first line of description
```

Description
```
 second line of description
 third line of description

```

Closes #20 

