### PR TITLE
fix: Null-pointer exception on the nodes list element

### DIFF
--- a/src/Dto/Parsing/ContextMapVisitor.php
+++ b/src/Dto/Parsing/ContextMapVisitor.php
@@ -84,7 +84,7 @@ final class ContextMapVisitor extends NodeVisitorAbstract
     /**
      * Collect all comments before traversal (called once).
      *
-     * @param Node[] $nodes
+     * @param array<Node|null> $nodes
      */
     public function beforeTraverse(array $nodes): ?array
     {
@@ -129,11 +129,15 @@ final class ContextMapVisitor extends NodeVisitorAbstract
     /**
      * Recursively collect all comments from AST.
      *
-     * @param Node[] $nodes
+     * @param array<Node|null> $nodes
      */
     private function collectAllCommentsPositions(array $nodes): void
     {
         foreach ($nodes as $node) {
+            if (!$node instanceof Node) {
+                continue;
+            }
+
             $this->collectNodeCommentsPositions($node);
             // Recursively collect from child nodes
             foreach ($node->getSubNodeNames() as $name) {


### PR DESCRIPTION
Array of nodes provided by `nikic/php-parser` for the visitor may contain `null` instead of `PhpParser\Node`