### PR TITLE
Fix: doc inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ Additionally, script supports [inline configuration](docs/inline_config.md) - ni
 of each created issue. It helps flexibly configure different aspects of created issues
 like labels, components, relations to other issues and so on. So, it becomes mighty tool. 😊
 
+Also, you can enable [sequential comments gluing](docs/sequential_comments_gluing.md) to treat
+consecutive single-line comments as a single multi-line comment for TODO processing.
+
 ### Supported tags
 
 It detects `TODO` and `FIXME` by default. At the same time, you can config your custom set of tags in config file.

--- a/docs/inline_config.md
+++ b/docs/inline_config.md
@@ -78,6 +78,18 @@ Below are examples of settings supported by the implemented JIRA-registrar.
    {EXTRAS: {labels: [label-a, label-b], components: [component-a, component-b]}}
    ```
 
+### Common keys supported by all registrars
+
+The following inline config keys are supported by all registrars:
+
+| Key | Description |
+|---|---|
+| assignee | Identifier of user to assign to the issue (string or array) |
+| assignees | Same as `assignee`. Both keys are supported |
+| contextTitle | Title of context path. Overrides `contextTitle` from general config |
+| labels | List of labels/tags which will be assigned to the issue |
+| showContext | Include code context in issue description. Overrides `showContext` from general config |
+
 ### Inline configs specific for issue trackers
 
 1. [GitHub](registrar/GitHub/config.md#inline-config)
@@ -88,6 +100,10 @@ Below are examples of settings supported by the implemented JIRA-registrar.
 
 
 ## The order of applying of configs
-1. `@assignee` joined to TODO-tag.
-2. `EXTRAS`
-3. Then the [general config](config/general_config_php.md) of the JIRA registrar.
+
+When the same field can be set from multiple sources, values are applied with the following priority
+(highest to lowest). This order applies to all registrars:
+
+1. **Tag assignee** — `@assignee` joined to TODO-tag (e.g. `TODO@john`)
+2. **Inline config** — values from `{EXTRAS: {...}}`
+3. **General config** — values from the [general config file](config/general_config.md)

--- a/docs/registrar/GitHub/config.md
+++ b/docs/registrar/GitHub/config.md
@@ -77,7 +77,10 @@ Supported keys of inline config:
 
 | Key | Description |
 |---|---|
+| assignee | Identifier of GitHub user as string, which will be assigned to the issue |
 | assignees | List of identifiers of GitHub users, which will be assigned to the issue |
+| contextTitle | Title of context path. Overrides `contextTitle` from general config |
 | labels | List of labels which will be assigned to the issue |
 | owner | username on GitHub |
 | repository | the name of repository (part URL to repository) |
+| showContext | Include code context in issue description. Overrides `showContext` from general config |

--- a/docs/registrar/GitHub/config.md
+++ b/docs/registrar/GitHub/config.md
@@ -12,26 +12,27 @@ directory.
 #...
 registrar:
   type: GitHub
-  issue:
-      repository: 'string'                    # required: the name of repository (part URL to repository)
-      owner: 'string'                         # optional: username on GitHub
-      assignees: ['an.assignee_1']            # optional: identifiers of GitHub users, which will be assigned to ticket
-                                              #           when "assignee-suffix" was not used with tag.
-      labels: ['a-label']                     # optional: list of labels which will be set to issue
-      addTagToLabels: true                    # optional: add detected tag into list of issue labels or not
-      tagPrefix: 'tag-'                       # optional: prefix which will be added to tag when "addTagToLabels=true"
-      allowedLabels: ['label-1', 'label-2']   # optional: list of allowed labels. If set, only labels from this
-                                              #           list will be applied to issues. Labels from inline
-                                              #           config, general config, and tag-based labels (if addTagToLabels=true)
-                                              #           will be filtered to match this list.
-      summaryPrefix: '[TODO] '                # optional: prefix which will be added to issue subject
-                                              #           supports dynamic placeholders: {tag}, {tag_caps}, {assignee}
-      showContext: 'numbered'                 # optional: include code context in issue description
-                                              #           values: null (default), 'arrow_chained', 'asterisk', 'code_block',
-                                              #                   'number_sign', 'numbered'
-      contextTitle: null                      # optional: title of context path
-  service:
-      personalAccessToken: '%env(GITHUB_PERSONAL_ACCESS_TOKEN)%',   # required: personal access-token
+  options:
+    issue:
+        repository: 'string'                    # required: the name of repository (part URL to repository)
+        owner: 'string'                         # optional: username on GitHub
+        assignees: ['an.assignee_1']            # optional: identifiers of GitHub users, which will be assigned to ticket
+                                                #           when "assignee-suffix" was not used with tag.
+        labels: ['a-label']                     # optional: list of labels which will be set to issue
+        addTagToLabels: true                    # optional: add detected tag into list of issue labels or not
+        tagPrefix: 'tag-'                       # optional: prefix which will be added to tag when "addTagToLabels=true"
+        allowedLabels: ['label-1', 'label-2']   # optional: list of allowed labels. If set, only labels from this
+                                                #           list will be applied to issues. Labels from inline
+                                                #           config, general config, and tag-based labels (if addTagToLabels=true)
+                                                #           will be filtered to match this list.
+        summaryPrefix: '[TODO] '                # optional: prefix which will be added to issue subject
+                                                #           supports dynamic placeholders: {tag}, {tag_caps}, {assignee}
+        showContext: 'numbered'                 # optional: include code context in issue description
+                                                #           values: null (default), 'arrow_chained', 'asterisk', 'code_block',
+                                                #                   'number_sign', 'numbered'
+        contextTitle: null                      # optional: title of context path
+    service:
+        personalAccessToken: '%env(GITHUB_PERSONAL_ACCESS_TOKEN)%',   # required: personal access-token
 ```
 
 ### PHP configuration

--- a/docs/registrar/GitLab/config.md
+++ b/docs/registrar/GitLab/config.md
@@ -141,9 +141,13 @@ Supported keys of inline config:
 | Key | Description |
 |---|---|
 | assignee | Identifier(s) of GitLab user(s) (username or email). Can be a string (single user) or array of strings (multiple users) |
+| assignees | Same as `assignee`. Both keys are supported |
+| contextTitle | Title of context path. Overrides `contextTitle` from general config |
+| due_date | Due date in format YYYY-MM-DD |
 | labels | List of labels which will be assigned to the issue |
 | milestone | either ID (integer: 123) or title (string) of milestone (optional) |
-| due_date | Due date in format YYYY-MM-DD |
+| project | Project ID (integer) or project path (string). Overrides `project` from general config |
+| showContext | Include code context in issue description. Overrides `showContext` from general config |
 
 ### Examples
 

--- a/docs/registrar/GitLab/config.md
+++ b/docs/registrar/GitLab/config.md
@@ -11,30 +11,31 @@ or php-config-file `.todo-registrar.php` ([example](../../../examples/GitLab/.to
 #...
 registrar:
   type: GitLab
-  issue:
-      project: 123                            # required: either project ID (integer: 123) or project path (string: owner/repo)
-      assignee: ['username1', 'username2']    # optional: String or array of strings. Identifiers of GitLab users (username or email),
-                                              #           which will be assigned to issue when "assignee-suffix"
-                                              #           was not used with tag.
-      labels: ['label-1', 'label-2']          # optional: list of labels which will be set to issue
-      addTagToLabels: true                    # optional: add detected tag into list of issue labels or not
-      tagPrefix: 'tag-'                       # optional: prefix which will be added to tag when "addTagToLabels=true"
-      allowedLabels: ['label-1', 'label-2']   # optional: list of allowed labels. If set, only labels from this
-                                              #           list will be applied to issues. Labels from inline
-                                              #           config, general config, and tag-based labels (if addTagToLabels=true)
-                                              #           will be filtered to match this list.
-      due_date: '2025-12-31'                  # optional: due date in format YYYY-MM-DD (optional)
-      milestone: 123                          # optional: either ID (integer: 123) or title (string) of milestone (optional)
-      summaryPrefix: '[TODO] '                # optional: prefix which will be added to issue subject
-                                              #           supports dynamic placeholders: {tag}, {tag_caps}, {assignee}
-      showContext: 'numbered'                 # optional: include code context in issue description
-                                              #           values: null (default), 'arrow_chained', 'asterisk', 'code_block',
-                                              #                   'number_sign', 'numbered'
-      contextTitle: null                      # optional: title of context path
-  service:
-      host: 'https://gitlab.com',                                   # optional: GitLab host URL (optional, defaults to https://gitlab.com)
-      personalAccessToken: '%env(GITLAB_PERSONAL_ACCESS_TOKEN)%',   # optional: personal access token (for http_token auth method)
-      oauthToken: '%env(GITLAB_PERSONAL_OAUTH_TOKEN)%',             # optional: OAuth token (for oauth_token auth method)
+  options:
+    issue:
+        project: 123                            # required: either project ID (integer: 123) or project path (string: owner/repo)
+        assignee: ['username1', 'username2']    # optional: String or array of strings. Identifiers of GitLab users (username or email),
+                                                #           which will be assigned to issue when "assignee-suffix"
+                                                #           was not used with tag.
+        labels: ['label-1', 'label-2']          # optional: list of labels which will be set to issue
+        addTagToLabels: true                    # optional: add detected tag into list of issue labels or not
+        tagPrefix: 'tag-'                       # optional: prefix which will be added to tag when "addTagToLabels=true"
+        allowedLabels: ['label-1', 'label-2']   # optional: list of allowed labels. If set, only labels from this
+                                                #           list will be applied to issues. Labels from inline
+                                                #           config, general config, and tag-based labels (if addTagToLabels=true)
+                                                #           will be filtered to match this list.
+        due_date: '2025-12-31'                  # optional: due date in format YYYY-MM-DD (optional)
+        milestone: 123                          # optional: either ID (integer: 123) or title (string) of milestone (optional)
+        summaryPrefix: '[TODO] '                # optional: prefix which will be added to issue subject
+                                                #           supports dynamic placeholders: {tag}, {tag_caps}, {assignee}
+        showContext: 'numbered'                 # optional: include code context in issue description
+                                                #           values: null (default), 'arrow_chained', 'asterisk', 'code_block',
+                                                #                   'number_sign', 'numbered'
+        contextTitle: null                      # optional: title of context path
+    service:
+        host: 'https://gitlab.com',                                   # optional: GitLab host URL (optional, defaults to https://gitlab.com)
+        personalAccessToken: '%env(GITLAB_PERSONAL_ACCESS_TOKEN)%',   # optional: personal access token (for http_token auth method)
+        oauthToken: '%env(GITLAB_PERSONAL_OAUTH_TOKEN)%',             # optional: OAuth token (for oauth_token auth method)
 ```
 
 ### PHP configuration

--- a/docs/registrar/JIRA/config.md
+++ b/docs/registrar/JIRA/config.md
@@ -71,6 +71,9 @@ And it can be overridden by inline config.
 
 Use `issueType` for the type of issue (e.g., Task, Bug, Story).
 
+> **Deprecated:** `type` is accepted as an alias of `issueType` in general config for backward compatibility.
+> If both `type` and `issueType` are specified, a validation error is raised. Use only `issueType`.
+
 ### Option allowedLabels
 
 See [allowed labels documentation](../../allowed_labels.md)

--- a/docs/registrar/JIRA/config.md
+++ b/docs/registrar/JIRA/config.md
@@ -11,37 +11,38 @@ or php-config-file `.todo-registrar.php` ([example](../../../examples/JIRA/.todo
 #...
 registrar:
   type: JIRA
-  issue:
-      projectKey: 'string'                    # required: key-name of project
-      issueType: 'Bug'                        # required: type of issue (e.g., Task, Bug, Story)
-      priority: 'string'                      # optional: priority of issue
-      assignee: 'string'                      # optional: identifier of JIRA-user, which will be assigned to ticket
-                                              #           when "assignee-suffix" was not used with tag.
-      labels: ['a-label']                     # optional: list of labels which will be set to issue
-      addTagToLabels: true                    # optional: add detected tag into list of issue labels or not
-      tagPrefix: 'tag-'                       # optional: prefix which will be added to tag when "addTagToLabels=true"
-      allowedLabels: ['label-1', 'label-2']   # optional: list of allowed labels. If set, only labels from this
-                                              #           list will be applied to issues. Labels from inline
-                                              #           config, general config, and tag-based labels (if addTagToLabels=true)
-                                              #           will be filtered to match this list.
-      components: ['a-component']             # optional: list of components which will be set to issue
-      summaryPrefix: '[TODO] '                # optional: prefix which will be added to issue subject
-                                              #           supports dynamic placeholders: {tag}, {tag_caps}, {assignee}
-      showContext: 'numbered'                 # optional: include code context in issue description
-                                              #           values: null (default), 'arrow_chained', 'asterisk', 'code_block',
-                                              #                   'number_sign', 'numbered'
-      contextTitle: null                      # optional: title of context path
-      issueLinkType: null                     # optional: Default linked issue type. If undefined then 'Relates' is used.
-  service:
-      host: '%env(JIRA_HOST)%'                                  # required: host of JIRA-server
-      personalAccessToken: '%env(JIRA_PERSONAL_ACCESS_TOKEN)%'  # optional: personal access-token
-      tokenBasedAuth: true                                      # optional: (default: false)
+  options:
+    issue:
+        projectKey: 'string'                    # required: key-name of project
+        issueType: 'Bug'                        # required: type of issue (e.g., Task, Bug, Story)
+        priority: 'string'                      # optional: priority of issue
+        assignee: 'string'                      # optional: identifier of JIRA-user, which will be assigned to ticket
+                                                #           when "assignee-suffix" was not used with tag.
+        labels: ['a-label']                     # optional: list of labels which will be set to issue
+        addTagToLabels: true                    # optional: add detected tag into list of issue labels or not
+        tagPrefix: 'tag-'                       # optional: prefix which will be added to tag when "addTagToLabels=true"
+        allowedLabels: ['label-1', 'label-2']   # optional: list of allowed labels. If set, only labels from this
+                                                #           list will be applied to issues. Labels from inline
+                                                #           config, general config, and tag-based labels (if addTagToLabels=true)
+                                                #           will be filtered to match this list.
+        components: ['a-component']             # optional: list of components which will be set to issue
+        summaryPrefix: '[TODO] '                # optional: prefix which will be added to issue subject
+                                                #           supports dynamic placeholders: {tag}, {tag_caps}, {assignee}
+        showContext: 'numbered'                 # optional: include code context in issue description
+                                                #           values: null (default), 'arrow_chained', 'asterisk', 'code_block',
+                                                #                   'number_sign', 'numbered'
+        contextTitle: null                      # optional: title of context path
+        issueLinkType: null                     # optional: Default linked issue type. If undefined then 'Relates' is used.
+    service:
+        host: '%env(JIRA_HOST)%'                                  # required: host of JIRA-server
+        personalAccessToken: '%env(JIRA_PERSONAL_ACCESS_TOKEN)%'  # optional: personal access-token
+        tokenBasedAuth: true                                      # optional: (default: false)
 
-      # JIRA username and password can be used as alternative for authentication on JIRA-server.
-      # So, previous option "tokenBasedAuth" must be set to "false".
-      #
-      # jiraUser: 'string'
-      # jiraPassword: 'string'
+        # JIRA username and password can be used as alternative for authentication on JIRA-server.
+        # So, previous option "tokenBasedAuth" must be set to "false".
+        #
+        # jiraUser: 'string'
+        # jiraPassword: 'string'
 ```
 
 ### PHP configuration

--- a/docs/registrar/JIRA/config.md
+++ b/docs/registrar/JIRA/config.md
@@ -74,6 +74,11 @@ Use `issueType` for the type of issue (e.g., Task, Bug, Story).
 > **Deprecated:** `type` is accepted as an alias of `issueType` in general config for backward compatibility.
 > If both `type` and `issueType` are specified, a validation error is raised. Use only `issueType`.
 
+### Option 'issueLinkType'
+
+Default link type used when linking issues via `linkedIssues` in inline config.
+If not set, `Relates` is used.
+
 ### Option allowedLabels
 
 See [allowed labels documentation](../../allowed_labels.md)
@@ -92,11 +97,14 @@ Supported keys of inline config:
 
 | Key | Description |
 |---|---|
-| assignees | One identifier of JIRA-users as string, which will be assigned to the issue. This one will be used when it is defined. |
-| components | List of components which will be set to issue. |
-| issue_type | Type of issue. Deprecated. Alias of 'issueType' |
-| issueType | Type of issue (task, bug, story, epic, etc.). |
+| assignee | Identifier of JIRA user as string, which will be assigned to the issue |
+| assignees | Same as `assignee`. Both keys are supported |
+| components | List of components which will be set to issue |
+| contextTitle | Title of context path. Overrides `contextTitle` from general config |
+| issue_type | Type of issue. Deprecated. Alias of `issueType` |
+| issueType | Type of issue (task, bug, story, epic, etc.) |
+| labels | List of labels which will be assigned to the issue |
 | linkedIssues | List of [linked issues](linked_issues.md) |
-| labels | List of labels which will be assigned to the issue. |
-| priority | Priority of issue as string. |
-| projectKey | Allow override project key to create issue in another related project. |
+| priority | Priority of issue as string |
+| projectKey | Allow override project key to create issue in another related project |
+| showContext | Include code context in issue description. Overrides `showContext` from general config |

--- a/docs/registrar/Redmine/config.md
+++ b/docs/registrar/Redmine/config.md
@@ -61,7 +61,9 @@ And it can be overridden by inline config.
 
 ### Labels
 
-Redmine doesn't support labels.
+Redmine doesn't support labels. The options `labels`, `addTagToLabels`, `tagPrefix`, and `allowedLabels`
+are accepted in the general config for compatibility with the base configuration,
+but they are ignored and have no effect on the created Redmine issues.
 
 ### Option showContext
 
@@ -176,13 +178,17 @@ Supported keys of inline config:
 | Key | Type | Description |
 |---|---|---|
 | assignee | `string` or `int` | Username/login/email or user ID to assign to the issue |
-| tracker | `int` or `string` | Tracker ID or name (Bug, Feature, Support, etc.) |
-| priority | `int` or `string` | Priority ID or name (High, Normal, Low, etc.) |
+| assignees | `string` or `int` | Same as `assignee`. Both keys are supported |
 | category | `int` or `string` | Category ID or name |
-| fixed_version | `int` or `string` | Version ID or name |
-| start_date | `string` | Start date in format YYYY-MM-DD |
+| contextTitle | `string` | Title of context path. Overrides `contextTitle` from general config |
 | due_date | `string` | Due date in format YYYY-MM-DD |
 | estimated_hours| `float` | Estimated hours |
+| fixed_version | `int` or `string` | Version ID or name |
+| priority | `int` or `string` | Priority ID or name (High, Normal, Low, etc.) |
+| project | `int` or `string` | Project identifier or ID. Overrides `project` from general config |
+| showContext | `string` | Include code context in issue description. Overrides `showContext` from general config |
+| start_date | `string` | Start date in format YYYY-MM-DD |
+| tracker | `int` or `string` | Tracker ID or name (Bug, Feature, Support, etc.) |
 
 ### Examples
 
@@ -210,8 +216,8 @@ Supported keys of inline config:
 
 When the same field can be set from multiple sources, priority is (highest to lowest):
 
-1. **Inline config** — `{EXTRAS: {assignee: user1}}`
-2. **Tag assignee** — `TODO@username`
+1. **Tag assignee** — `TODO@username`
+2. **Inline config** — `{EXTRAS: {assignee: user1}}`
 3. **Global config** — `issue.assignee` in config file
 
 ### Assignee examples

--- a/docs/registrar/Redmine/config.md
+++ b/docs/registrar/Redmine/config.md
@@ -11,28 +11,29 @@ or php-config-file `.todo-registrar.php` ([example](../../../examples/Redmine/.t
 #...
 registrar:
   type: Redmine
-  issue:
-    project: 'testing-project'          # required: project identifier or ID
-    tracker: 'Bugs'                     # required: tracker name or ID
-    priority: 'Low'                     # optional: priority name or ID
-    assignee: null                      # optional: username, login, email, or user ID
-    category: null                      # optional: category name or ID
-    fixed_version: null                 # optional: version name or ID
-    start_date: null                    # optional: start date in format YYYY-MM-DD
-    due_date: null                      # optional: due date in format YYYY-MM-DD
-    estimated_hours: null               # optional: estimated hours as float
-    summaryPrefix: '[TODO] '            # optional: prefix which will be added to issue subject
-                                        #           supports dynamic placeholders: {tag}, {tag_caps}, {assignee}
-    showContext: 'numbered'             # optional: include code context in issue description
-                                        #           values: null (default), 'arrow_chained', 'asterisk', 'code_block',
-                                        #                   'number_sign', 'numbered'
-    contextTitle: null                  # optional: title of context path
-  service:
-    url: 'https://redmine.example.com',             # required: Redmine URL
-    apikeyOrUsername: '%env(REDMINE_USERNAME)%',    # required: API key (recommended) or username
-    password: '%env(REDMINE_PASSWORD)%',            # optional: password for Basic Auth
-                                                    #           If password is provided, Basic Auth will be used (username:password)
-                                                    #           Otherwise, apikeyOrUsername will be treated as API key
+  options:
+    issue:
+      project: 'testing-project'          # required: project identifier or ID
+      tracker: 'Bugs'                     # required: tracker name or ID
+      priority: 'Low'                     # optional: priority name or ID
+      assignee: null                      # optional: username, login, email, or user ID
+      category: null                      # optional: category name or ID
+      fixed_version: null                 # optional: version name or ID
+      start_date: null                    # optional: start date in format YYYY-MM-DD
+      due_date: null                      # optional: due date in format YYYY-MM-DD
+      estimated_hours: null               # optional: estimated hours as float
+      summaryPrefix: '[TODO] '            # optional: prefix which will be added to issue subject
+                                          #           supports dynamic placeholders: {tag}, {tag_caps}, {assignee}
+      showContext: 'numbered'             # optional: include code context in issue description
+                                          #           values: null (default), 'arrow_chained', 'asterisk', 'code_block',
+                                          #                   'number_sign', 'numbered'
+      contextTitle: null                  # optional: title of context path
+    service:
+      url: 'https://redmine.example.com',             # required: Redmine URL
+      apikeyOrUsername: '%env(REDMINE_USERNAME)%',    # required: API key (recommended) or username
+      password: '%env(REDMINE_PASSWORD)%',            # optional: password for Basic Auth
+                                                      #           If password is provided, Basic Auth will be used (username:password)
+                                                      #           Otherwise, apikeyOrUsername will be treated as API key
 ```
 
 ### PHP configuration

--- a/docs/registrar/YandexTracker/config.md
+++ b/docs/registrar/YandexTracker/config.md
@@ -11,32 +11,33 @@ or php-config-file `.todo-registrar.php` ([example](../../../examples/YandexTrac
 #...
 registrar:
   type: YandexTracker
-  issue:
-    queue: MYQUEUE                                  # required: key of Yandex Tracker queue (required)
-    type: task                                      # required: type of issue (task, bug, story, epic, etc.)
-    priority: normal                                # priority of issue (blocker, critical, normal, minor, trivial)
-    assignee: developer.login                       # optional: login of Yandex Tracker user, which will be assigned to issue
-                                                    #           when "assignee-suffix" was not used with tag
-    labels:                                         # optional: list of tags which will be set to issue
-      - tech-debt
-      - from-code
-    addTagToLabels: true                            # optional: add detected tag into list of issue tags or not
-    tagPrefix: 'tag-'                               # optional: prefix which will be added to tag when "addTagToLabels=true"
-    allowedLabels: [tech-debt, another-label]       # optional: list of allowed tags. If set, only tags from this
-                                                    #           list will be applied to issues. Tags from inline
-                                                    #           config, general config, and tag-based tags (if addTagToLabels=true)
-                                                    #           will be filtered to match this list.
-    summaryPrefix: '[TODO] '                        # optional: prefix which will be added to issue summary
-                                                    #           supports dynamic placeholders: {tag}, {tag_caps}, {assignee}
-    showContext: 'numbered'                         # optional: include code context in issue description
-                                                    #           values: null (default), 'arrow_chained', 'asterisk', 'code_block',
-                                                    #                   'number_sign', 'numbered'
-    contextTitle: null                              # optional: title of context path
-  service:
-    orgId: '%env(YANDEX_TRACKER_ORG_ID)%'           # required: Organization ID (required)
-    token: '%env(YANDEX_TRACKER_TOKEN)%'            # required: OAuth token for Yandex Tracker API (required)
-    isCloud: true                                   # optional: Is Cloud Organization (is not passes then default: true)
-                                                    #           If true, X-Cloud-Org-ID header is passed instead of X-Org-ID
+  options:
+    issue:
+      queue: MYQUEUE                                  # required: key of Yandex Tracker queue (required)
+      type: task                                      # required: type of issue (task, bug, story, epic, etc.)
+      priority: normal                                # priority of issue (blocker, critical, normal, minor, trivial)
+      assignee: developer.login                       # optional: login of Yandex Tracker user, which will be assigned to issue
+                                                      #           when "assignee-suffix" was not used with tag
+      labels:                                         # optional: list of tags which will be set to issue
+        - tech-debt
+        - from-code
+      addTagToLabels: true                            # optional: add detected tag into list of issue tags or not
+      tagPrefix: 'tag-'                               # optional: prefix which will be added to tag when "addTagToLabels=true"
+      allowedLabels: [tech-debt, another-label]       # optional: list of allowed tags. If set, only tags from this
+                                                      #           list will be applied to issues. Tags from inline
+                                                      #           config, general config, and tag-based tags (if addTagToLabels=true)
+                                                      #           will be filtered to match this list.
+      summaryPrefix: '[TODO] '                        # optional: prefix which will be added to issue summary
+                                                      #           supports dynamic placeholders: {tag}, {tag_caps}, {assignee}
+      showContext: 'numbered'                         # optional: include code context in issue description
+                                                      #           values: null (default), 'arrow_chained', 'asterisk', 'code_block',
+                                                      #                   'number_sign', 'numbered'
+      contextTitle: null                              # optional: title of context path
+    service:
+      orgId: '%env(YANDEX_TRACKER_ORG_ID)%'           # required: Organization ID (required)
+      token: '%env(YANDEX_TRACKER_TOKEN)%'            # required: OAuth token for Yandex Tracker API (required)
+      isCloud: true                                   # optional: Is Cloud Organization (is not passes then default: true)
+                                                      #           If true, X-Cloud-Org-ID header is passed instead of X-Org-ID
 ```
 
 ### PHP configuration

--- a/docs/registrar/YandexTracker/config.md
+++ b/docs/registrar/YandexTracker/config.md
@@ -91,11 +91,15 @@ Supported keys of [inline config](../../inline_config.md):
 
 | Key | Description |
 |---|---|
-| assignee | Login of Yandex Tracker user as string, which will be assigned to the issue. This one will be used when it is defined. |
-| issue_type | Type of issue. Deprecated. Alias of 'issueType' |
-| issueType | Type of issue (task, bug, story, epic, etc.). |
-| labels | List of tags which will be assigned to the issue. |
-| priority | Priority of issue as string (blocker, critical, normal, minor, trivial). |
+| assignee | Login of Yandex Tracker user as string, which will be assigned to the issue |
+| assignees | Same as `assignee`. Both keys are supported |
+| contextTitle | Title of context path. Overrides `contextTitle` from general config |
+| issue_type | Type of issue. Deprecated. Alias of `issueType` |
+| issueType | Type of issue (task, bug, story, epic, etc.) |
+| labels | List of tags which will be assigned to the issue |
+| priority | Priority of issue as string (blocker, critical, normal, minor, trivial) |
+| queue | Key of Yandex Tracker queue. Overrides `queue` from general config |
+| showContext | Include code context in issue description. Overrides `showContext` from general config |
 
 ### Example of inline config
 

--- a/docs/supported_patters_of_comments.md
+++ b/docs/supported_patters_of_comments.md
@@ -38,6 +38,20 @@ and multiple-line comments `/* ... */` and phpDoc `/** ... **/`.
    ```
 
 
+### Sequential Comments Gluing
+
+Consecutive single-line comments (`//` or `#`) can be glued into one multi-line comment
+when [sequential comments gluing](sequential_comments_gluing.md) is enabled in configuration.
+
+```php
+// TODO: Implement authentication
+//       - Add login form
+//       - Validate credentials
+```
+
+Without gluing (default) only the first line is processed as TODO.
+With gluing enabled all three lines are processed as one TODO comment.
+
 ### Assignee-part
 
 It is some "username" which separated of tag by symbol "@". It sticks to pattern `/[a-z0-9._-]+/i`.

--- a/examples/GitLab/.todo-registrar.yaml
+++ b/examples/GitLab/.todo-registrar.yaml
@@ -16,7 +16,7 @@ registrar:
       # Replace with your actual project identifier (or set GITLAB_PROJECT_IDENTIFIER environment variable)
       project: '%env(GITLAB_PROJECT_IDENTIFIER)%'
       addTagToLabels: true
-      assignees:
+      assignee:
         - username1
         - username2
       labels:

--- a/examples/YandexTracker/.todo-registrar.yaml
+++ b/examples/YandexTracker/.todo-registrar.yaml
@@ -7,20 +7,21 @@ paths:
 
 registrar:
   type: YandexTracker
-  queue: MYQUEUE
-  issue:
-    addTagToLabels: true
-    assignee: developer.login
-    labels:
-      - tech-debt
-      - from-code
-    priority: normal
-    tagPrefix: ''
-    type: task
-  service:
-    isCloud: '%env(YANDEX_TRACKER_IS_CLOUD)%'
-    orgId: '%env(YANDEX_TRACKER_ORG_ID)%'
-    token: '%env(YANDEX_TRACKER_TOKEN)%'
+  options:
+    issue:
+      queue: MYQUEUE
+      type: task
+      priority: normal
+      assignee: developer.login
+      addTagToLabels: true
+      labels:
+        - tech-debt
+        - from-code
+      tagPrefix: ''
+    service:
+      isCloud: '%env(YANDEX_TRACKER_IS_CLOUD)%'
+      orgId: '%env(YANDEX_TRACKER_ORG_ID)%'
+      token: '%env(YANDEX_TRACKER_TOKEN)%'
 
 tags:
   - todo


### PR DESCRIPTION
### Changes:

- **All 5 registrar config docs** (`GitHub`, `GitLab`, `JIRA`, `Redmine`, `YandexTracker`): described missing `options` wrapper to YAML examples to match actual config structure defined in `RegistrarConfig`
- **Inline config tables**: described undocumented but code-supported keys across all registrars:
  - `showContext` and `contextTitle` (overrides from general config, handled by `IssueSupporter`)
  - `assignee`/`assignees` cross-support (both keys work for all registrars)
  - `project` for GitLab and Redmine
  - `queue` for Yandex Tracker
- **JIRA config**: described `issueLinkType` option description; described deprecation note for `type` alias of `issueType` in general config
- **Redmine config**: clarified that `labels`, `addTagToLabels`, `tagPrefix`, `allowedLabels` are accepted but ignored
- **`docs/inline_config.md`**: described "Common keys supported by all registrars" section; fixed and generalized "The order of applying of configs" (was JIRA-specific, now applies to all registrars); fixed priority order (tag assignee > inline config > general config)
- **`examples/YandexTracker/.todo-registrar.yaml`**: fixed broken structure — described `options` wrapper, moved `queue` inside `issue` section
- **`examples/GitLab/.todo-registrar.yaml`**: fixed `assignees` → `assignee` to match the property name in `GeneralIssueConfig`
- Update visibility of consecutive single-line comments gluing description