### PR TITLE
Prefer getting of issueLinkType for JIRA in issues config

### DIFF
--- a/docs/registrar/JIRA/config.md
+++ b/docs/registrar/JIRA/config.md
@@ -79,6 +79,8 @@ Use `issueType` for the type of issue (e.g., Task, Bug, Story).
 Default link type used when linking issues via `linkedIssues` in inline config.
 If not set, `Relates` is used.
 
+It is expected that `issueLinkType` is in `issue` array, but script tries to get it from root too.
+
 ### Option allowedLabels
 
 See [allowed labels documentation](../../allowed_labels.md)

--- a/docs/registrar/JIRA/linked_issues.md
+++ b/docs/registrar/JIRA/linked_issues.md
@@ -24,13 +24,15 @@ The created issue will be linked to `PROJ-100` with the default link type.
 ## Default link type
 
 If you don't specify a link type, the value from the `issueLinkType` option
-in the [general config](config.md) is used. If that option is not set either,
-the default is `Relates`.
+in the `issue` section of the [general config](config.md) is used.
+If that option is not set either, the script falls back to `issueLinkType`
+at the root of registrar options (for backward compatibility). If neither is defined, the default is `Relates`.
 
 ```yaml
 registrar:
-  issue:
-    issueLinkType: 'Blocks'   # change the default link type
+  options:
+    issue:
+      issueLinkType: 'Blocks'   # change the default link type
 ```
 
 ## Usage formats

--- a/src/Service/Registrar/JIRA/JiraRegistrarFactory.php
+++ b/src/Service/Registrar/JIRA/JiraRegistrarFactory.php
@@ -38,7 +38,7 @@ final readonly class JiraRegistrarFactory implements RegistrarFactoryInterface
         $issueConfig = ($config['issue'] ?? []) + ['projectKey' => $config['projectKey'] ?? null];
         $generalIssueConfig = $this->createGeneralIssueConfig($issueConfig, $validator);
 
-        $defaultIssueLinkType = $config['issueLinkType'] ?? 'Relates';
+        $defaultIssueLinkType = $issueConfig['issueLinkType'] ?? $config['issueLinkType'] ?? 'Relates';
         $serviceFactory = new ServiceFactory($config['service']);
         $issueLinkService = $serviceFactory->createIssueLinkService();
 


### PR DESCRIPTION
Get option `issueLinkType` from `issue` option as described in documentation

```yaml
registrar:
  options:
    issue:
      issueLinkType: 'Relates'
```

And saved deprecated behavior when it is got as root option

```yaml
registrar:
  options:
    issueLinkType: 'Relates'
```