### PR TITLE
Prepare for upgrade to new interfaces model

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "ext-simplexml": "*",
         "ext-tokenizer": "*",
         "aeliot/env-resolver": "^1.0.2",
-        "aeliot/todo-registrar-contracts": "^2.2.0",
+        "aeliot/todo-registrar-contracts": "^2.3.0",
         "bugrov/yandex-tracker": "0.1.0",
         "guzzlehttp/guzzle": "^7.9",
         "http-interop/http-factory-guzzle": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee5b128b4753fb496585f95efcee354d",
+    "content-hash": "c4c2161bc56cfce13d08031a782b15f9",
     "packages": [
         {
             "name": "aeliot/env-resolver",
@@ -54,16 +54,16 @@
         },
         {
             "name": "aeliot/todo-registrar-contracts",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Aeliot-Tm/todo-registrar-contracts.git",
-                "reference": "ac156d7e0700a572cd2f48aa6d8f4ca000143c0a"
+                "reference": "83a8218f26e273fc8ebf2dab7ebef2515d96a7fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Aeliot-Tm/todo-registrar-contracts/zipball/ac156d7e0700a572cd2f48aa6d8f4ca000143c0a",
-                "reference": "ac156d7e0700a572cd2f48aa6d8f4ca000143c0a",
+                "url": "https://api.github.com/repos/Aeliot-Tm/todo-registrar-contracts/zipball/83a8218f26e273fc8ebf2dab7ebef2515d96a7fe",
+                "reference": "83a8218f26e273fc8ebf2dab7ebef2515d96a7fe",
                 "shasum": ""
             },
             "require": {
@@ -100,9 +100,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Aeliot-Tm/todo-registrar-contracts/issues",
-                "source": "https://github.com/Aeliot-Tm/todo-registrar-contracts/tree/2.2.0"
+                "source": "https://github.com/Aeliot-Tm/todo-registrar-contracts/tree/2.3.0"
             },
-            "time": "2026-02-27T10:32:51+00:00"
+            "time": "2026-06-01T15:28:57+00:00"
         },
         {
             "name": "bugrov/yandex-tracker",
@@ -4407,6 +4407,6 @@
         "ext-simplexml": "*",
         "ext-tokenizer": "*"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }

--- a/docs/config/general_config_php.md
+++ b/docs/config/general_config_php.md
@@ -2,7 +2,7 @@
 
 > There is described php-form of [general config file](general_config.md).
 
-Config file have to returns instance of interface `Aeliot\TodoRegistrarContracts\GeneralConfigInterface`.
+Config file have to returns instance of interface `Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface`.
 
 You may implement it yourself (read about [customization](../customization.md))
 or use existing class `Aeliot\TodoRegistrar\Config`.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -11,7 +11,7 @@ Look no the **processing schema**:
 First of all, you may want to implement **Registrar** for your custom API.
 It has to implement interface `Aeliot\TodoRegistrarContracts\RegistrarInterface`
 
-It accepts interface of TODO object (`Aeliot\TodoRegistrarContracts\TodoInterface`) and returns identifier (`string`) of created issue.
+It accepts interface of TODO object (`Aeliot\TodoRegistrarContracts\Todo\TodoInterface`) and returns identifier (`string`) of created issue.
 In short, returned identifier have to match one of patterns:
 - `/\#\d++/`
 - `/[A-Z0-9]++-\d++/`
@@ -51,7 +51,7 @@ Nevertheless, you may implement your own. Just implement interface `Aeliot\TodoR
 
 Finally, have to pass all that stuff as [global config](config/general_config.md).
 If you decided implement [PHP version of global config](config/general_config_php.md)
-then implement `Aeliot\TodoRegistrarContracts\GeneralConfigInterface`.
+then implement `Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface`.
 
 ## Contracts package
 

--- a/src/Dto/GeneralConfig/IssueKeyInjectionConfig.php
+++ b/src/Dto/GeneralConfig/IssueKeyInjectionConfig.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Dto\GeneralConfig;
 
 use Aeliot\TodoRegistrar\Enum\IssueKeyPosition;
-use Aeliot\TodoRegistrarContracts\IssueKeyInjectionConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\IssueKeyInjectionConfigInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 final class IssueKeyInjectionConfig implements IssueKeyInjectionConfigInterface

--- a/src/Dto/GeneralConfig/ProcessConfig.php
+++ b/src/Dto/GeneralConfig/ProcessConfig.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Dto\GeneralConfig;
 
-use Aeliot\TodoRegistrarContracts\ProcessConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\ProcessConfigInterface;
 use Aeliot\TodoRegistrarContracts\ProcessSameTicketConfigInterface;
 
 final class ProcessConfig implements ProcessConfigInterface, ProcessSameTicketConfigInterface

--- a/src/Dto/Parsing/ContextInterface.php
+++ b/src/Dto/Parsing/ContextInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Dto\Parsing;
 
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\ContextNodeInterface;
 
 interface ContextInterface
 {

--- a/src/Dto/Parsing/ContextMapVisitor.php
+++ b/src/Dto/Parsing/ContextMapVisitor.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Dto\Parsing;
 
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\PhpContextNodeInterface;
 use PhpParser\Node;
 use PhpParser\Node\Const_;
 use PhpParser\Node\Expr\ArrowFunction;
@@ -70,7 +70,7 @@ final class ContextMapVisitor extends NodeVisitorAbstract
 
     public function __construct(string $filePath)
     {
-        $this->stack = [new ContextNode(ContextNodeInterface::KIND_FILE, $filePath)];
+        $this->stack = [new ContextNode(PhpContextNodeInterface::KIND_FILE, $filePath)];
     }
 
     /**
@@ -172,59 +172,59 @@ final class ContextMapVisitor extends NodeVisitorAbstract
     {
         return match (true) {
             $node instanceof ArrowFunction => new ContextNode(
-                ContextNodeInterface::KIND_ARROW_FUNCTION,
+                PhpContextNodeInterface::KIND_ARROW_FUNCTION,
                 null
             ),
             $node instanceof Class_ => new ContextNode(
-                ContextNodeInterface::KIND_CLASS,
+                PhpContextNodeInterface::KIND_CLASS,
                 $node->name?->toString()
             ),
             $node instanceof ClassConst => new ContextNode(
-                ContextNodeInterface::KIND_CLASS_CONST,
+                PhpContextNodeInterface::KIND_CLASS_CONST,
                 $this->getClassConstName($node)
             ),
             $node instanceof Closure => new ContextNode(
-                ContextNodeInterface::KIND_CLOSURE,
+                PhpContextNodeInterface::KIND_CLOSURE,
                 null
             ),
             $node instanceof Enum_ => new ContextNode(
-                ContextNodeInterface::KIND_ENUM,
+                PhpContextNodeInterface::KIND_ENUM,
                 $node->name->toString()
             ),
             $node instanceof EnumCase => new ContextNode(
-                ContextNodeInterface::KIND_ENUM_CASE,
+                PhpContextNodeInterface::KIND_ENUM_CASE,
                 $node->name->toString()
             ),
             $node instanceof Function_ => new ContextNode(
-                ContextNodeInterface::KIND_FUNCTION,
+                PhpContextNodeInterface::KIND_FUNCTION,
                 $node->name->toString()
             ),
             $node instanceof Interface_ => new ContextNode(
-                ContextNodeInterface::KIND_INTERFACE,
+                PhpContextNodeInterface::KIND_INTERFACE,
                 $node->name->toString()
             ),
             $node instanceof Match_ => new ContextNode(
-                ContextNodeInterface::KIND_MATCH,
+                PhpContextNodeInterface::KIND_MATCH,
                 null
             ),
             $node instanceof ClassMethod => new ContextNode(
-                ContextNodeInterface::KIND_METHOD,
+                PhpContextNodeInterface::KIND_METHOD,
                 $node->name->toString()
             ),
             $node instanceof Namespace_ => new ContextNode(
-                ContextNodeInterface::KIND_NAMESPACE,
+                PhpContextNodeInterface::KIND_NAMESPACE,
                 $node->name?->toString()
             ),
             $node instanceof Param => new ContextNode(
-                ContextNodeInterface::KIND_PARAMETER,
+                PhpContextNodeInterface::KIND_PARAMETER,
                 $node->var instanceof Node\Expr\Variable && \is_string($node->var->name) ? $node->var->name : null
             ),
             $node instanceof Property => new ContextNode(
-                ContextNodeInterface::KIND_PROPERTY,
+                PhpContextNodeInterface::KIND_PROPERTY,
                 $this->getPropertyName($node)
             ),
             $node instanceof Trait_ => new ContextNode(
-                ContextNodeInterface::KIND_TRAIT,
+                PhpContextNodeInterface::KIND_TRAIT,
                 $node->name->toString()
             ),
             default => null,
@@ -338,17 +338,17 @@ final class ContextMapVisitor extends NodeVisitorAbstract
     {
         $previousKinds = match (true) {
             $node instanceof ClassConst, $node instanceof Property => [
-                ContextNodeInterface::KIND_CLASS,
-                ContextNodeInterface::KIND_TRAIT,
+                PhpContextNodeInterface::KIND_CLASS,
+                PhpContextNodeInterface::KIND_TRAIT,
             ],
             $node instanceof EnumCase => [
-                ContextNodeInterface::KIND_ENUM,
+                PhpContextNodeInterface::KIND_ENUM,
             ],
             $node instanceof Param => [
-                ContextNodeInterface::KIND_METHOD,
-                ContextNodeInterface::KIND_FUNCTION,
-                ContextNodeInterface::KIND_CLOSURE,
-                ContextNodeInterface::KIND_ARROW_FUNCTION,
+                PhpContextNodeInterface::KIND_METHOD,
+                PhpContextNodeInterface::KIND_FUNCTION,
+                PhpContextNodeInterface::KIND_CLOSURE,
+                PhpContextNodeInterface::KIND_ARROW_FUNCTION,
             ],
             default => null,
         };

--- a/src/Dto/Parsing/ContextNode.php
+++ b/src/Dto/Parsing/ContextNode.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Dto\Parsing;
 
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\ContextNodeInterface;
 
 /**
  * Represents a single element in the context hierarchy (file, namespace, class, method, etc.).

--- a/src/Dto/Registrar/Todo.php
+++ b/src/Dto/Registrar/Todo.php
@@ -16,13 +16,15 @@ namespace Aeliot\TodoRegistrar\Dto\Registrar;
 use Aeliot\TodoRegistrar\Dto\Comment\CommentPart;
 use Aeliot\TodoRegistrar\Enum\IssueKeyPosition;
 use Aeliot\TodoRegistrarContracts\ContextAwareTodoInterface;
-use Aeliot\TodoRegistrarContracts\HashAwareInterface;
 use Aeliot\TodoRegistrarContracts\InlineConfigInterface;
+use Aeliot\TodoRegistrarContracts\Todo\ContextAwareInterface;
+use Aeliot\TodoRegistrarContracts\Todo\HashAwareInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
  * @internal
  */
-class Todo implements ContextAwareTodoInterface, HashAwareInterface
+class Todo implements ContextAwareInterface, HashAwareInterface, TodoInterface, ContextAwareTodoInterface
 {
     public function __construct(
         protected string $tag,

--- a/src/Dto/Registrar/Todo.php
+++ b/src/Dto/Registrar/Todo.php
@@ -53,6 +53,9 @@ class Todo implements ContextAwareInterface, HashAwareInterface, TodoInterface, 
         return $this->commentPart;
     }
 
+    /**
+     * @return \Aeliot\TodoRegistrarContracts\Context\ContextNodeInterface[]|\Aeliot\TodoRegistrarContracts\ContextNodeInterface[]
+     */
     public function getContext(): array
     {
         return $this->commentPart->getContext()->getContextNodes();

--- a/src/Service/CommentExtractorFactory.php
+++ b/src/Service/CommentExtractorFactory.php
@@ -18,8 +18,8 @@ use Aeliot\TodoRegistrar\Dto\GeneralConfig\IssueKeyInjectionConfig;
 use Aeliot\TodoRegistrar\Service\Comment\CommentCleanerRegistry;
 use Aeliot\TodoRegistrar\Service\Comment\Extractor as CommentExtractor;
 use Aeliot\TodoRegistrar\Service\Tag\Detector as TagDetector;
-use Aeliot\TodoRegistrarContracts\GeneralConfigInterface;
-use Aeliot\TodoRegistrarContracts\IssueKeyInjectionAwareGeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\IssueKeyInjectionConfigAwareInterface;
 
 /**
  * @internal
@@ -33,7 +33,7 @@ final readonly class CommentExtractorFactory
     public function create(GeneralConfigInterface $config): CommentExtractor
     {
         $separators = [];
-        if ($config instanceof IssueKeyInjectionAwareGeneralConfigInterface) {
+        if ($config instanceof IssueKeyInjectionConfigAwareInterface) {
             $separators = $config->getIssueKeyInjectionConfig()?->getSummarySeparators();
         }
         if (!$separators) {

--- a/src/Service/Config/ConfigFactory.php
+++ b/src/Service/Config/ConfigFactory.php
@@ -15,7 +15,7 @@ namespace Aeliot\TodoRegistrar\Service\Config;
 
 use Aeliot\TodoRegistrar\Exception\NotSupportedConfigException;
 use Aeliot\TodoRegistrar\Exception\UnavailableConfigException;
-use Aeliot\TodoRegistrarContracts\GeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
 
 /**
  * @internal

--- a/src/Service/Config/ConfigProvider.php
+++ b/src/Service/Config/ConfigProvider.php
@@ -15,7 +15,7 @@ namespace Aeliot\TodoRegistrar\Service\Config;
 
 use Aeliot\TodoRegistrar\Exception\ConfigValidationException;
 use Aeliot\TodoRegistrar\Exception\InvalidConfigException;
-use Aeliot\TodoRegistrarContracts\GeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**

--- a/src/Service/Config/StdinConfigFactory.php
+++ b/src/Service/Config/StdinConfigFactory.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Config;
 
 use Aeliot\TodoRegistrar\Exception\UnavailableConfigException;
-use Aeliot\TodoRegistrarContracts\GeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
 
 /**
  * @internal

--- a/src/Service/ContextPath/Builder/AbstractContextPathBuilder.php
+++ b/src/Service/ContextPath/Builder/AbstractContextPathBuilder.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Service\ContextPath\Builder;
 
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\PhpContextNodeInterface;
 
 abstract readonly class AbstractContextPathBuilder
 {
@@ -28,21 +29,21 @@ abstract readonly class AbstractContextPathBuilder
 
         foreach ($nodes as $node) {
             $lines[] = match ($node->getKind()) {
-                ContextNodeInterface::KIND_ARROW_FUNCTION => 'Arrow function',
-                ContextNodeInterface::KIND_CLASS => 'Class: ' . ($node->getName() ?? '{anonymous}'),
-                ContextNodeInterface::KIND_CLASS_CONST => 'Constant: ' . ($node->getName() ?? '{unknown}'),
-                ContextNodeInterface::KIND_CLOSURE => 'Closure',
-                ContextNodeInterface::KIND_ENUM => "Enum: {$node->getName()}",
-                ContextNodeInterface::KIND_ENUM_CASE => "Enum case: {$node->getName()}",
-                ContextNodeInterface::KIND_FILE => "File: {$node->getName()}",
-                ContextNodeInterface::KIND_FUNCTION => "Function: {$node->getName()}()",
-                ContextNodeInterface::KIND_INTERFACE => "Interface: {$node->getName()}",
-                ContextNodeInterface::KIND_MATCH => 'Match expression',
-                ContextNodeInterface::KIND_METHOD => "Method: {$node->getName()}()",
-                ContextNodeInterface::KIND_NAMESPACE => "Namespace: {$node->getName()}",
-                ContextNodeInterface::KIND_PARAMETER => 'Parameter: ' . ($node->getName() ?? '{unknown}'),
-                ContextNodeInterface::KIND_PROPERTY => 'Property: ' . ($node->getName() ?? '{unknown}'),
-                ContextNodeInterface::KIND_TRAIT => "Trait: {$node->getName()}",
+                PhpContextNodeInterface::KIND_ARROW_FUNCTION => 'Arrow function',
+                PhpContextNodeInterface::KIND_CLASS => 'Class: ' . ($node->getName() ?? '{anonymous}'),
+                PhpContextNodeInterface::KIND_CLASS_CONST => 'Constant: ' . ($node->getName() ?? '{unknown}'),
+                PhpContextNodeInterface::KIND_CLOSURE => 'Closure',
+                PhpContextNodeInterface::KIND_ENUM => "Enum: {$node->getName()}",
+                PhpContextNodeInterface::KIND_ENUM_CASE => "Enum case: {$node->getName()}",
+                PhpContextNodeInterface::KIND_FILE => "File: {$node->getName()}",
+                PhpContextNodeInterface::KIND_FUNCTION => "Function: {$node->getName()}()",
+                PhpContextNodeInterface::KIND_INTERFACE => "Interface: {$node->getName()}",
+                PhpContextNodeInterface::KIND_MATCH => 'Match expression',
+                PhpContextNodeInterface::KIND_METHOD => "Method: {$node->getName()}()",
+                PhpContextNodeInterface::KIND_NAMESPACE => "Namespace: {$node->getName()}",
+                PhpContextNodeInterface::KIND_PARAMETER => 'Parameter: ' . ($node->getName() ?? '{unknown}'),
+                PhpContextNodeInterface::KIND_PROPERTY => 'Property: ' . ($node->getName() ?? '{unknown}'),
+                PhpContextNodeInterface::KIND_TRAIT => "Trait: {$node->getName()}",
                 default => ucfirst($node->getKind()) . ($node->getName() ? ": {$node->getName()}" : ''),
             };
         }

--- a/src/Service/ContextPath/ContextPathBuilderInterface.php
+++ b/src/Service/ContextPath/ContextPathBuilderInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Service\ContextPath;
 
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\ContextNodeInterface;
 
 interface ContextPathBuilderInterface
 {

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -142,6 +142,7 @@ final readonly class HeapRunner
             $processConfig instanceof ProcessSameTicketConfigInterface
             || (
                 $processConfig instanceof ProcessConfigAwareInterface
+                // @phpstan-ignore-next-line
                 && method_exists($processConfig, 'isGlueSameTicket')
             )
         ) {

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -24,10 +24,11 @@ use Aeliot\TodoRegistrar\Service\Comment\Extractor as CommentExtractor;
 use Aeliot\TodoRegistrar\Service\File\FileParser;
 use Aeliot\TodoRegistrar\Service\File\Saver;
 use Aeliot\TodoRegistrarContracts\FinderInterface;
-use Aeliot\TodoRegistrarContracts\GeneralConfigInterface;
-use Aeliot\TodoRegistrarContracts\ProcessAwareGeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\ProcessConfigAwareInterface;
 use Aeliot\TodoRegistrarContracts\ProcessSameTicketConfigInterface;
-use Aeliot\TodoRegistrarContracts\RegistrarInterface;
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface;
+use Aeliot\TodoRegistrarContracts\RegistrarInterface as LegacyRegistrarInterface;
 
 /**
  * @internal
@@ -39,7 +40,7 @@ final readonly class HeapRunner
         private FinderInterface $finder,
         private FileParser $fileParser,
         private OutputAdapter $output,
-        private RegistrarInterface $registrar,
+        private RegistrarInterface|LegacyRegistrarInterface $registrar,
         private Saver $saver,
         private TodoBuilder $todoBuilder,
         private GeneralConfigInterface $config,
@@ -132,18 +133,27 @@ final readonly class HeapRunner
 
     private function getGlueSameTickets(): bool
     {
-        $processConfig = $this->config instanceof ProcessAwareGeneralConfigInterface
+        $processConfig = $this->config instanceof ProcessConfigAwareInterface
             ? $this->config->getProcessConfig()
             : null;
 
-        return ($processConfig instanceof ProcessSameTicketConfigInterface
-            ? $processConfig->isGlueSameTicket()
-            : null) ?? ProcessConfig::DEFAULT_GLUE_SAME_TICKETS;
+        $isGlueSameTicket = null;
+        if (
+            $processConfig instanceof ProcessSameTicketConfigInterface
+            || (
+                $processConfig instanceof ProcessConfigAwareInterface
+                && method_exists($processConfig, 'isGlueSameTicket')
+            )
+        ) {
+            $isGlueSameTicket = $processConfig->isGlueSameTicket();
+        }
+
+        return $isGlueSameTicket ?? ProcessConfig::DEFAULT_GLUE_SAME_TICKETS;
     }
 
     private function getGlueSequentialComments(): bool
     {
-        return ($this->config instanceof ProcessAwareGeneralConfigInterface
+        return ($this->config instanceof ProcessConfigAwareInterface
             ? $this->config->getProcessConfig()?->isGlueSequentialComments()
             : null) ?? ProcessConfig::DEFAULT_GLUE_SEQUENTIAL_COMMENTS;
     }

--- a/src/Service/Registrar/GitHub/GitHubRegistrar.php
+++ b/src/Service/Registrar/GitHub/GitHubRegistrar.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Registrar\GitHub;
 
 use Aeliot\TodoRegistrarContracts\RegistrarInterface;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
  * @internal

--- a/src/Service/Registrar/GitHub/IssueFactory.php
+++ b/src/Service/Registrar/GitHub/IssueFactory.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Registrar\GitHub;
 
 use Aeliot\TodoRegistrar\Service\Registrar\IssueSupporter;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
  * @internal

--- a/src/Service/Registrar/GitLab/GitlabRegistrar.php
+++ b/src/Service/Registrar/GitLab/GitlabRegistrar.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Registrar\GitLab;
 
 use Aeliot\TodoRegistrarContracts\RegistrarInterface;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
  * @internal

--- a/src/Service/Registrar/GitLab/IssueFactory.php
+++ b/src/Service/Registrar/GitLab/IssueFactory.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Registrar\GitLab;
 
 use Aeliot\TodoRegistrar\Service\Registrar\IssueSupporter;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
  * @internal

--- a/src/Service/Registrar/IssueSupporter.php
+++ b/src/Service/Registrar/IssueSupporter.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Registrar;
 
 use Aeliot\TodoRegistrar\Service\ContextPath\ContextPathBuilderRegistry;
-use Aeliot\TodoRegistrarContracts\ContextAwareTodoInterface;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\ContextAwareInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 final readonly class IssueSupporter
 {
@@ -49,7 +49,7 @@ final readonly class IssueSupporter
         $description = $todo->getDescription();
 
         if (
-            $todo instanceof ContextAwareTodoInterface
+            $todo instanceof ContextAwareInterface
             && ($context = $todo->getContext())
             && ($showContext = ($todo->getInlineConfig()['showContext'] ?? $generalIssueConfig->getShowContext()))
         ) {

--- a/src/Service/Registrar/JIRA/IssueFieldFactory.php
+++ b/src/Service/Registrar/JIRA/IssueFieldFactory.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Registrar\JIRA;
 
 use Aeliot\TodoRegistrar\Service\Registrar\IssueSupporter;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 use JiraRestApi\Issue\IssueField;
 
 /**

--- a/src/Service/Registrar/JIRA/IssueLinkRegistrar.php
+++ b/src/Service/Registrar/JIRA/IssueLinkRegistrar.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Service\Registrar\JIRA;
 
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 use JiraRestApi\IssueLink\IssueLink;
 use JiraRestApi\IssueLink\IssueLinkService;
 

--- a/src/Service/Registrar/JIRA/JiraRegistrar.php
+++ b/src/Service/Registrar/JIRA/JiraRegistrar.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Registrar\JIRA;
 
 use Aeliot\TodoRegistrarContracts\RegistrarInterface;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 use JiraRestApi\Issue\IssueService;
 
 /**

--- a/src/Service/Registrar/Redmine/IssueFactory.php
+++ b/src/Service/Registrar/Redmine/IssueFactory.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Registrar\Redmine;
 
 use Aeliot\TodoRegistrar\Service\Registrar\IssueSupporter;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
  * @internal

--- a/src/Service/Registrar/Redmine/RedmineRegistrar.php
+++ b/src/Service/Registrar/Redmine/RedmineRegistrar.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Registrar\Redmine;
 
 use Aeliot\TodoRegistrarContracts\RegistrarInterface;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
  * @internal

--- a/src/Service/Registrar/RegistrarFactoryRegistry.php
+++ b/src/Service/Registrar/RegistrarFactoryRegistry.php
@@ -15,7 +15,8 @@ namespace Aeliot\TodoRegistrar\Service\Registrar;
 
 use Aeliot\TodoRegistrar\Enum\RegistrarType;
 use Aeliot\TodoRegistrar\Exception\InvalidConfigException;
-use Aeliot\TodoRegistrarContracts\RegistrarFactoryInterface;
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarFactoryInterface;
+use Aeliot\TodoRegistrarContracts\RegistrarFactoryInterface as LegacyRegistrarFactoryInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
@@ -25,7 +26,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 final readonly class RegistrarFactoryRegistry
 {
     /**
-     * @param ServiceLocator<RegistrarFactoryInterface> $registrarFactoryLocator
+     * @param ServiceLocator<RegistrarFactoryInterface|LegacyRegistrarFactoryInterface> $registrarFactoryLocator
      */
     public function __construct(
         #[AutowireLocator('aeliot.todo_registrar.registrar_factory')]
@@ -33,7 +34,7 @@ final readonly class RegistrarFactoryRegistry
     ) {
     }
 
-    public function getFactory(RegistrarType $type): RegistrarFactoryInterface
+    public function getFactory(RegistrarType $type): RegistrarFactoryInterface|LegacyRegistrarFactoryInterface
     {
         if (!$this->registrarFactoryLocator->has($type->value)) {
             throw new InvalidConfigException(\sprintf('Not supported registrar type "%s"', $type->value));

--- a/src/Service/Registrar/YandexTracker/IssueFactory.php
+++ b/src/Service/Registrar/YandexTracker/IssueFactory.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service\Registrar\YandexTracker;
 
 use Aeliot\TodoRegistrar\Service\Registrar\IssueSupporter;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
  * @internal

--- a/src/Service/RegistrarProvider.php
+++ b/src/Service/RegistrarProvider.php
@@ -51,6 +51,7 @@ final readonly class RegistrarProvider
             $registrarFactory = $this->getByEnumValue($registrarType);
         }
 
+        // @phpstan-ignore-next-line
         return $registrarFactory->create($config->getRegistrarConfig(), $this->validator);
     }
 

--- a/src/Service/RegistrarProvider.php
+++ b/src/Service/RegistrarProvider.php
@@ -16,9 +16,11 @@ namespace Aeliot\TodoRegistrar\Service;
 use Aeliot\TodoRegistrar\Enum\RegistrarType;
 use Aeliot\TodoRegistrar\Exception\InvalidConfigException;
 use Aeliot\TodoRegistrar\Service\Registrar\RegistrarFactoryRegistry;
-use Aeliot\TodoRegistrarContracts\GeneralConfigInterface;
-use Aeliot\TodoRegistrarContracts\RegistrarFactoryInterface;
-use Aeliot\TodoRegistrarContracts\RegistrarInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarFactoryInterface;
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface;
+use Aeliot\TodoRegistrarContracts\RegistrarFactoryInterface as LegacyRegistrarFactoryInterface;
+use Aeliot\TodoRegistrarContracts\RegistrarInterface as LegacyRegistrarInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -32,13 +34,18 @@ final readonly class RegistrarProvider
     ) {
     }
 
-    public function getRegistrar(GeneralConfigInterface $config): RegistrarInterface
+    public function getRegistrar(GeneralConfigInterface $config): RegistrarInterface|LegacyRegistrarInterface
     {
         $registrarType = $config->getRegistrarType();
 
-        if ($registrarType instanceof RegistrarFactoryInterface) {
+        if ($registrarType instanceof RegistrarFactoryInterface || $registrarType instanceof LegacyRegistrarFactoryInterface) {
             $registrarFactory = $registrarType;
-        } elseif (class_exists($registrarType) && is_a($registrarType, RegistrarFactoryInterface::class, true)) {
+        } elseif (class_exists($registrarType)
+            && (
+                is_a($registrarType, RegistrarFactoryInterface::class, true)
+                || is_a($registrarType, LegacyRegistrarFactoryInterface::class, true)
+            )
+        ) {
             $registrarFactory = new $registrarType();
         } else {
             $registrarFactory = $this->getByEnumValue($registrarType);
@@ -47,7 +54,7 @@ final readonly class RegistrarProvider
         return $registrarFactory->create($config->getRegistrarConfig(), $this->validator);
     }
 
-    private function getByEnumValue(string $registrarType): RegistrarFactoryInterface
+    private function getByEnumValue(string $registrarType): RegistrarFactoryInterface|LegacyRegistrarFactoryInterface
     {
         // add some backward compatibility
         if ('github' === strtolower($registrarType)) {

--- a/src/Service/TodoBuilderFactory.php
+++ b/src/Service/TodoBuilderFactory.php
@@ -18,8 +18,12 @@ use Aeliot\TodoRegistrar\Dto\GeneralConfig\IssueKeyInjectionConfig;
 use Aeliot\TodoRegistrar\Enum\IssueKeyPosition;
 use Aeliot\TodoRegistrar\Service\InlineConfig\ExtrasReader;
 use Aeliot\TodoRegistrar\Service\InlineConfig\InlineConfigFactory;
-use Aeliot\TodoRegistrarContracts\GeneralConfigInterface;
-use Aeliot\TodoRegistrarContracts\IssueKeyInjectionAwareGeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\InlineConfigFactoryAwareInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\InlineConfigReaderAwareInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\IssueKeyInjectionConfigAwareInterface;
+use Aeliot\TodoRegistrarContracts\InlineConfigFactoryInterface;
+use Aeliot\TodoRegistrarContracts\InlineConfigReaderInterface;
 
 /**
  * @internal
@@ -34,12 +38,13 @@ final readonly class TodoBuilderFactory
 
     public function create(GeneralConfigInterface $config, OutputAdapter $output): TodoBuilder
     {
-        $inlineConfigReader = $config->getInlineConfigReader() ?? $this->extrasReader;
-        $inlineConfigFactory = $config->getInlineConfigFactory() ?? $this->inlineConfigFactory;
+        $inlineConfigFactory = $this->getInlineConfigFactory($config);
+        $inlineConfigReader = $this->getInlineConfigReader($config);
+
         $issueKeyPosition = null;
         $newSeparator = null;
         $replaceSeparator = null;
-        if ($config instanceof IssueKeyInjectionAwareGeneralConfigInterface) {
+        if ($config instanceof IssueKeyInjectionConfigAwareInterface) {
             $injectionConfig = $config->getIssueKeyInjectionConfig();
             $issueKeyPosition = $injectionConfig?->getPosition();
             $newSeparator = $injectionConfig?->getNewSeparator();
@@ -49,5 +54,25 @@ final readonly class TodoBuilderFactory
         $replaceSeparator ??= IssueKeyInjectionConfig::DEFAULT_REPLACE_SEPARATOR;
 
         return new TodoBuilder($inlineConfigFactory, $inlineConfigReader, $issueKeyPosition, $newSeparator, $output, $replaceSeparator);
+    }
+
+    private function getInlineConfigFactory(GeneralConfigInterface $config): InlineConfigFactoryInterface
+    {
+        $inlineConfigFactory = null;
+        if ($config instanceof InlineConfigFactoryAwareInterface) {
+            $inlineConfigFactory = $config->getInlineConfigFactory();
+        }
+
+        return $inlineConfigFactory ?? $this->inlineConfigFactory;
+    }
+
+    private function getInlineConfigReader(GeneralConfigInterface $config): InlineConfigReaderInterface
+    {
+        $inlineConfigReader = null;
+        if ($config instanceof InlineConfigReaderAwareInterface) {
+            $inlineConfigReader = $config->getInlineConfigReader();
+        }
+
+        return $inlineConfigReader ?? $this->extrasReader;
     }
 }

--- a/tests/Functional/RegisterCommandTest.php
+++ b/tests/Functional/RegisterCommandTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Test\Functional;
 
+use Aeliot\TodoRegistrar\Test\Stub\NewStaticRegistrarFactory;
 use Aeliot\TodoRegistrar\Test\Stub\StaticRegistrarFactory;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -75,11 +76,32 @@ final class RegisterCommandTest extends TestCase
         yield 'YAML config' => ['yaml'];
     }
 
-    #[DataProvider('configProvider')]
-    public function testRegisterWithStubRegistrar(string $configType): void
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function registrarFactoryClassProvider(): iterable
+    {
+        yield 'legacy registrar factory' => [StaticRegistrarFactory::class];
+        yield 'new registrar factory' => [NewStaticRegistrarFactory::class];
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: class-string}>
+     */
+    public static function registerWithStubRegistrarProvider(): iterable
+    {
+        foreach (self::configProvider() as $configLabel => [$configType]) {
+            foreach (self::registrarFactoryClassProvider() as $factoryLabel => [$factoryClass]) {
+                yield "{$configLabel}, {$factoryLabel}" => [$configType, $factoryClass];
+            }
+        }
+    }
+
+    #[DataProvider('registerWithStubRegistrarProvider')]
+    public function testRegisterWithStubRegistrar(string $configType, string $stubFactoryClass): void
     {
         $expectedTicketKey = 'TEST-456';
-        $configFile = $this->createConfigFile($configType, $expectedTicketKey);
+        $configFile = $this->createConfigFile($configType, $expectedTicketKey, $stubFactoryClass);
         file_put_contents($this->testFile, self::ORIGINAL_CONTENT);
 
         if ('yaml' === $configType) {
@@ -219,19 +241,23 @@ final class RegisterCommandTest extends TestCase
         );
     }
 
-    private function createConfigFile(string $type, string $ticketKey): string
-    {
+    private function createConfigFile(
+        string $type,
+        string $ticketKey,
+        string $stubFactoryClass = StaticRegistrarFactory::class,
+    ): string {
         if ('php' === $type) {
-            return $this->createPhpConfig($ticketKey);
+            return $this->createPhpConfig($ticketKey, $stubFactoryClass);
         }
 
-        return $this->createYamlConfig();
+        return $this->createYamlConfig($stubFactoryClass);
     }
 
-    private function createPhpConfig(string $ticketKey): string
-    {
+    private function createPhpConfig(
+        string $ticketKey,
+        string $stubFactoryClass = StaticRegistrarFactory::class,
+    ): string {
         $configFile = $this->tempDir . '/.todo-registrar.php';
-        $stubFactoryClass = StaticRegistrarFactory::class;
         $configContent = <<<PHP
 <?php
 
@@ -252,18 +278,17 @@ PHP;
         return $configFile;
     }
 
-    private function createYamlConfig(): string
+    private function createYamlConfig(string $stubFactoryClass = StaticRegistrarFactory::class): string
     {
         $configFile = $this->tempDir . '/.todo-registrar.yaml';
-        $configContent = $this->buildYamlConfigContent();
+        $configContent = $this->buildYamlConfigContent($stubFactoryClass);
         file_put_contents($configFile, $configContent);
 
         return $configFile;
     }
 
-    private function buildYamlConfigContent(): string
+    private function buildYamlConfigContent(string $stubFactoryClass = StaticRegistrarFactory::class): string
     {
-        $stubFactoryClass = StaticRegistrarFactory::class;
         $ticketKeyEnvVar = self::TICKET_KEY_ENV_VAR_NAME;
 
         return <<<YAML

--- a/tests/Stub/IncrementalKeyRegistrar.php
+++ b/tests/Stub/IncrementalKeyRegistrar.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Test\Stub;
 
 use Aeliot\TodoRegistrarContracts\RegistrarInterface;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
  * Stub registrar for testing purposes.

--- a/tests/Stub/LegacyConfig.php
+++ b/tests/Stub/LegacyConfig.php
@@ -11,27 +11,27 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Aeliot\TodoRegistrar;
+namespace Aeliot\TodoRegistrar\Test\Stub;
 
 use Aeliot\TodoRegistrar\Dto\GeneralConfig\IssueKeyInjectionConfig;
 use Aeliot\TodoRegistrar\Dto\GeneralConfig\ProcessConfig;
 use Aeliot\TodoRegistrar\Enum\RegistrarType;
 use Aeliot\TodoRegistrarContracts\FinderInterface;
-use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
-use Aeliot\TodoRegistrarContracts\GeneralConfig\InlineConfigFactoryAwareInterface;
-use Aeliot\TodoRegistrarContracts\GeneralConfig\InlineConfigReaderAwareInterface;
-use Aeliot\TodoRegistrarContracts\GeneralConfig\IssueKeyInjectionConfigAwareInterface;
-use Aeliot\TodoRegistrarContracts\GeneralConfig\IssueKeyInjectionConfigInterface;
-use Aeliot\TodoRegistrarContracts\GeneralConfig\ProcessConfigAwareInterface;
-use Aeliot\TodoRegistrarContracts\GeneralConfig\ProcessConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfigInterface;
 use Aeliot\TodoRegistrarContracts\InlineConfigFactoryInterface;
 use Aeliot\TodoRegistrarContracts\InlineConfigReaderInterface;
-use Aeliot\TodoRegistrarContracts\Registrar\RegistrarFactoryInterface;
-use Aeliot\TodoRegistrarContracts\RegistrarFactoryInterface as LegacyRegistrarFactoryInterface;
+use Aeliot\TodoRegistrarContracts\IssueKeyInjectionAwareGeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\IssueKeyInjectionConfigInterface;
+use Aeliot\TodoRegistrarContracts\ProcessAwareGeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\ProcessConfigInterface;
+use Aeliot\TodoRegistrarContracts\RegistrarFactoryInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
-class Config implements GeneralConfigInterface, InlineConfigFactoryAwareInterface, InlineConfigReaderAwareInterface, IssueKeyInjectionConfigAwareInterface, ProcessConfigAwareInterface
+/**
+ * User config stub as it was before contracts migration (deprecated root interfaces).
+ */
+final class LegacyConfig implements GeneralConfigInterface, IssueKeyInjectionAwareGeneralConfigInterface, ProcessAwareGeneralConfigInterface
 {
     public const DEFAULT_TAGS = ['todo', 'fixme'];
 
@@ -52,7 +52,7 @@ class Config implements GeneralConfigInterface, InlineConfigFactoryAwareInterfac
      * @var array<string,mixed>
      */
     private array $registrarConfig;
-    private RegistrarFactoryInterface|string|LegacyRegistrarFactoryInterface $registrarType;
+    private RegistrarFactoryInterface|string $registrarType;
 
     /**
      * @var string[]
@@ -120,7 +120,7 @@ class Config implements GeneralConfigInterface, InlineConfigFactoryAwareInterfac
         return $this->registrarConfig;
     }
 
-    public function getRegistrarType(): RegistrarFactoryInterface|LegacyRegistrarFactoryInterface|string
+    public function getRegistrarType(): RegistrarFactoryInterface|string
     {
         return $this->registrarType;
     }
@@ -128,7 +128,7 @@ class Config implements GeneralConfigInterface, InlineConfigFactoryAwareInterfac
     /**
      * @param array<string,mixed> $config
      */
-    public function setRegistrar(RegistrarType|RegistrarFactoryInterface|LegacyRegistrarFactoryInterface|string $type, array $config): self
+    public function setRegistrar(RegistrarType|RegistrarFactoryInterface|string $type, array $config): self
     {
         if ($type instanceof RegistrarType) {
             $type = $type->value;

--- a/tests/Stub/NewStaticKeyRegistrar.php
+++ b/tests/Stub/NewStaticKeyRegistrar.php
@@ -11,29 +11,24 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Aeliot\TodoRegistrar\Service\Registrar\YandexTracker;
+namespace Aeliot\TodoRegistrar\Test\Stub;
 
-use Aeliot\TodoRegistrarContracts\RegistrarInterface;
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface;
 use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
- * @internal
+ * Stub registrar for testing purposes (new contracts interfaces).
+ * Does not make any API calls, returns ticket key from config.
  */
-final readonly class YandexTrackerRegistrar implements RegistrarInterface
+final class NewStaticKeyRegistrar implements RegistrarInterface
 {
     public function __construct(
-        private IssueFactory $issueFactory,
+        private string $ticketKey,
     ) {
     }
 
     public function register(TodoInterface $todo): string
     {
-        $request = $this->issueFactory->create($todo);
-        $response = $request->send();
-
-        /** @var string $key */
-        $key = $response->getField('key');
-
-        return $key;
+        return $this->ticketKey;
     }
 }

--- a/tests/Stub/NewStaticRegistrarFactory.php
+++ b/tests/Stub/NewStaticRegistrarFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Test\Stub;
+
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarFactoryInterface;
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface;
+
+/**
+ * Stub registrar factory for testing purposes (new contracts interfaces).
+ * Creates NewStaticKeyRegistrar instances without making any API calls.
+ */
+final class NewStaticRegistrarFactory implements RegistrarFactoryInterface
+{
+    public function create(array $config): RegistrarInterface
+    {
+        return new NewStaticKeyRegistrar($config['ticket_key']);
+    }
+}

--- a/tests/Stub/StaticKeyRegistrar.php
+++ b/tests/Stub/StaticKeyRegistrar.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Test\Stub;
 
 use Aeliot\TodoRegistrarContracts\RegistrarInterface;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 
 /**
  * Stub registrar for testing purposes.

--- a/tests/Unit/Service/Config/ConfigProviderTest.php
+++ b/tests/Unit/Service/Config/ConfigProviderTest.php
@@ -26,7 +26,7 @@ use Aeliot\TodoRegistrar\Service\Config\ConfigProvider;
 use Aeliot\TodoRegistrar\Service\Config\StdinConfigFactory;
 use Aeliot\TodoRegistrar\Service\Config\YamlParser;
 use Aeliot\TodoRegistrar\Service\ValidatorFactory;
-use Aeliot\TodoRegistrarContracts\GeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Service/ContextPath/Builder/ArrowContextPathBuilderTest.php
+++ b/tests/Unit/Service/ContextPath/Builder/ArrowContextPathBuilderTest.php
@@ -15,7 +15,7 @@ namespace Aeliot\TodoRegistrar\Test\Unit\Service\ContextPath\Builder;
 
 use Aeliot\TodoRegistrar\Dto\Parsing\ContextNode;
 use Aeliot\TodoRegistrar\Service\ContextPath\Builder\ArrowContextPathBuilder;
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\PhpContextNodeInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -28,12 +28,12 @@ final class ArrowContextPathBuilderTest extends TestCase
         yield [
             "File: /path/to/file -> Class: MyClass -> Method: doSomething() -> Closure -> Class: {anonymous} -> Property: aProperty\n",
             [
-                new ContextNode(ContextNodeInterface::KIND_FILE, '/path/to/file'),
-                new ContextNode(ContextNodeInterface::KIND_CLASS, 'MyClass'),
-                new ContextNode(ContextNodeInterface::KIND_METHOD, 'doSomething'),
-                new ContextNode(ContextNodeInterface::KIND_CLOSURE, null),
-                new ContextNode(ContextNodeInterface::KIND_CLASS, null),
-                new ContextNode(ContextNodeInterface::KIND_PROPERTY, 'aProperty'),
+                new ContextNode(PhpContextNodeInterface::KIND_FILE, '/path/to/file'),
+                new ContextNode(PhpContextNodeInterface::KIND_CLASS, 'MyClass'),
+                new ContextNode(PhpContextNodeInterface::KIND_METHOD, 'doSomething'),
+                new ContextNode(PhpContextNodeInterface::KIND_CLOSURE, null),
+                new ContextNode(PhpContextNodeInterface::KIND_CLASS, null),
+                new ContextNode(PhpContextNodeInterface::KIND_PROPERTY, 'aProperty'),
             ],
         ];
     }

--- a/tests/Unit/Service/ContextPath/Builder/AsteriskContextPathBuilderTest.php
+++ b/tests/Unit/Service/ContextPath/Builder/AsteriskContextPathBuilderTest.php
@@ -15,7 +15,7 @@ namespace Aeliot\TodoRegistrar\Test\Unit\Service\ContextPath\Builder;
 
 use Aeliot\TodoRegistrar\Dto\Parsing\ContextNode;
 use Aeliot\TodoRegistrar\Service\ContextPath\Builder\AsteriskContextPathBuilder;
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\PhpContextNodeInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -33,12 +33,12 @@ final class AsteriskContextPathBuilderTest extends TestCase
             . "* Class: {anonymous}\n"
             . "* Property: aProperty\n",
             [
-                new ContextNode(ContextNodeInterface::KIND_FILE, '/path/to/file'),
-                new ContextNode(ContextNodeInterface::KIND_CLASS, 'MyClass'),
-                new ContextNode(ContextNodeInterface::KIND_METHOD, 'doSomething'),
-                new ContextNode(ContextNodeInterface::KIND_CLOSURE, null),
-                new ContextNode(ContextNodeInterface::KIND_CLASS, null),
-                new ContextNode(ContextNodeInterface::KIND_PROPERTY, 'aProperty'),
+                new ContextNode(PhpContextNodeInterface::KIND_FILE, '/path/to/file'),
+                new ContextNode(PhpContextNodeInterface::KIND_CLASS, 'MyClass'),
+                new ContextNode(PhpContextNodeInterface::KIND_METHOD, 'doSomething'),
+                new ContextNode(PhpContextNodeInterface::KIND_CLOSURE, null),
+                new ContextNode(PhpContextNodeInterface::KIND_CLASS, null),
+                new ContextNode(PhpContextNodeInterface::KIND_PROPERTY, 'aProperty'),
             ],
         ];
     }

--- a/tests/Unit/Service/ContextPath/Builder/CodeBlockContextPathBuilderTest.php
+++ b/tests/Unit/Service/ContextPath/Builder/CodeBlockContextPathBuilderTest.php
@@ -15,7 +15,7 @@ namespace Aeliot\TodoRegistrar\Test\Unit\Service\ContextPath\Builder;
 
 use Aeliot\TodoRegistrar\Dto\Parsing\ContextNode;
 use Aeliot\TodoRegistrar\Service\ContextPath\Builder\CodeBlockContextPathBuilder;
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\PhpContextNodeInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -35,12 +35,12 @@ final class CodeBlockContextPathBuilderTest extends TestCase
             . "Property: aProperty\n"
             . "```\n",
             [
-                new ContextNode(ContextNodeInterface::KIND_FILE, '/path/to/file'),
-                new ContextNode(ContextNodeInterface::KIND_CLASS, 'MyClass'),
-                new ContextNode(ContextNodeInterface::KIND_METHOD, 'doSomething'),
-                new ContextNode(ContextNodeInterface::KIND_CLOSURE, null),
-                new ContextNode(ContextNodeInterface::KIND_CLASS, null),
-                new ContextNode(ContextNodeInterface::KIND_PROPERTY, 'aProperty'),
+                new ContextNode(PhpContextNodeInterface::KIND_FILE, '/path/to/file'),
+                new ContextNode(PhpContextNodeInterface::KIND_CLASS, 'MyClass'),
+                new ContextNode(PhpContextNodeInterface::KIND_METHOD, 'doSomething'),
+                new ContextNode(PhpContextNodeInterface::KIND_CLOSURE, null),
+                new ContextNode(PhpContextNodeInterface::KIND_CLASS, null),
+                new ContextNode(PhpContextNodeInterface::KIND_PROPERTY, 'aProperty'),
             ],
         ];
     }

--- a/tests/Unit/Service/ContextPath/Builder/NumberSignContextPathBuilderTest.php
+++ b/tests/Unit/Service/ContextPath/Builder/NumberSignContextPathBuilderTest.php
@@ -15,7 +15,7 @@ namespace Aeliot\TodoRegistrar\Test\Unit\Service\ContextPath\Builder;
 
 use Aeliot\TodoRegistrar\Dto\Parsing\ContextNode;
 use Aeliot\TodoRegistrar\Service\ContextPath\Builder\NumberSignContextPathBuilder;
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\PhpContextNodeInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -33,12 +33,12 @@ final class NumberSignContextPathBuilderTest extends TestCase
             . "# Class: {anonymous}\n"
             . "# Property: aProperty\n",
             [
-                new ContextNode(ContextNodeInterface::KIND_FILE, '/path/to/file'),
-                new ContextNode(ContextNodeInterface::KIND_CLASS, 'MyClass'),
-                new ContextNode(ContextNodeInterface::KIND_METHOD, 'doSomething'),
-                new ContextNode(ContextNodeInterface::KIND_CLOSURE, null),
-                new ContextNode(ContextNodeInterface::KIND_CLASS, null),
-                new ContextNode(ContextNodeInterface::KIND_PROPERTY, 'aProperty'),
+                new ContextNode(PhpContextNodeInterface::KIND_FILE, '/path/to/file'),
+                new ContextNode(PhpContextNodeInterface::KIND_CLASS, 'MyClass'),
+                new ContextNode(PhpContextNodeInterface::KIND_METHOD, 'doSomething'),
+                new ContextNode(PhpContextNodeInterface::KIND_CLOSURE, null),
+                new ContextNode(PhpContextNodeInterface::KIND_CLASS, null),
+                new ContextNode(PhpContextNodeInterface::KIND_PROPERTY, 'aProperty'),
             ],
         ];
     }

--- a/tests/Unit/Service/ContextPath/Builder/NumberedContextPathBuilderTest.php
+++ b/tests/Unit/Service/ContextPath/Builder/NumberedContextPathBuilderTest.php
@@ -15,7 +15,7 @@ namespace Aeliot\TodoRegistrar\Test\Unit\Service\ContextPath\Builder;
 
 use Aeliot\TodoRegistrar\Dto\Parsing\ContextNode;
 use Aeliot\TodoRegistrar\Service\ContextPath\Builder\NumberedContextPathBuilder;
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\PhpContextNodeInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -33,12 +33,12 @@ final class NumberedContextPathBuilderTest extends TestCase
             . "5. Class: {anonymous}\n"
             . "6. Property: aProperty\n",
             [
-                new ContextNode(ContextNodeInterface::KIND_FILE, '/path/to/file'),
-                new ContextNode(ContextNodeInterface::KIND_CLASS, 'MyClass'),
-                new ContextNode(ContextNodeInterface::KIND_METHOD, 'doSomething'),
-                new ContextNode(ContextNodeInterface::KIND_CLOSURE, null),
-                new ContextNode(ContextNodeInterface::KIND_CLASS, null),
-                new ContextNode(ContextNodeInterface::KIND_PROPERTY, 'aProperty'),
+                new ContextNode(PhpContextNodeInterface::KIND_FILE, '/path/to/file'),
+                new ContextNode(PhpContextNodeInterface::KIND_CLASS, 'MyClass'),
+                new ContextNode(PhpContextNodeInterface::KIND_METHOD, 'doSomething'),
+                new ContextNode(PhpContextNodeInterface::KIND_CLOSURE, null),
+                new ContextNode(PhpContextNodeInterface::KIND_CLASS, null),
+                new ContextNode(PhpContextNodeInterface::KIND_PROPERTY, 'aProperty'),
             ],
         ];
     }

--- a/tests/Unit/Service/File/FileParserContextTest.php
+++ b/tests/Unit/Service/File/FileParserContextTest.php
@@ -19,7 +19,8 @@ use Aeliot\TodoRegistrar\Dto\Parsing\ParsedFile;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
 use Aeliot\TodoRegistrar\Service\File\FileParser;
 use Aeliot\TodoRegistrar\Service\File\Saver;
-use Aeliot\TodoRegistrarContracts\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\ContextNodeInterface;
+use Aeliot\TodoRegistrarContracts\Context\PhpContextNodeInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -215,21 +216,21 @@ final class FileParserContextTest extends TestCase
 
         foreach ($nodes as $node) {
             $lines[] = match ($node->getKind()) {
-                ContextNodeInterface::KIND_ARROW_FUNCTION => 'Arrow function',
-                ContextNodeInterface::KIND_CLASS => 'Class: ' . ($node->getName() ?? '{anonymous}'),
-                ContextNodeInterface::KIND_CLASS_CONST => 'Constant: ' . ($node->getName() ?? '{unknown}'),
-                ContextNodeInterface::KIND_CLOSURE => 'Closure',
-                ContextNodeInterface::KIND_ENUM => "Enum: {$node->getName()}",
-                ContextNodeInterface::KIND_ENUM_CASE => "Enum case: {$node->getName()}",
-                ContextNodeInterface::KIND_FILE => "File: {$node->getName()}",
-                ContextNodeInterface::KIND_FUNCTION => "Function: {$node->getName()}()",
-                ContextNodeInterface::KIND_INTERFACE => "Interface: {$node->getName()}",
-                ContextNodeInterface::KIND_MATCH => 'Match expression',
-                ContextNodeInterface::KIND_METHOD => "Method: {$node->getName()}()",
-                ContextNodeInterface::KIND_NAMESPACE => "Namespace: {$node->getName()}",
-                ContextNodeInterface::KIND_PARAMETER => 'Parameter: ' . ($node->getName() ?? '{unknown}'),
-                ContextNodeInterface::KIND_PROPERTY => 'Property: ' . ($node->getName() ?? '{unknown}'),
-                ContextNodeInterface::KIND_TRAIT => "Trait: {$node->getName()}",
+                PhpContextNodeInterface::KIND_ARROW_FUNCTION => 'Arrow function',
+                PhpContextNodeInterface::KIND_CLASS => 'Class: ' . ($node->getName() ?? '{anonymous}'),
+                PhpContextNodeInterface::KIND_CLASS_CONST => 'Constant: ' . ($node->getName() ?? '{unknown}'),
+                PhpContextNodeInterface::KIND_CLOSURE => 'Closure',
+                PhpContextNodeInterface::KIND_ENUM => "Enum: {$node->getName()}",
+                PhpContextNodeInterface::KIND_ENUM_CASE => "Enum case: {$node->getName()}",
+                PhpContextNodeInterface::KIND_FILE => "File: {$node->getName()}",
+                PhpContextNodeInterface::KIND_FUNCTION => "Function: {$node->getName()}()",
+                PhpContextNodeInterface::KIND_INTERFACE => "Interface: {$node->getName()}",
+                PhpContextNodeInterface::KIND_MATCH => 'Match expression',
+                PhpContextNodeInterface::KIND_METHOD => "Method: {$node->getName()}()",
+                PhpContextNodeInterface::KIND_NAMESPACE => "Namespace: {$node->getName()}",
+                PhpContextNodeInterface::KIND_PARAMETER => 'Parameter: ' . ($node->getName() ?? '{unknown}'),
+                PhpContextNodeInterface::KIND_PROPERTY => 'Property: ' . ($node->getName() ?? '{unknown}'),
+                PhpContextNodeInterface::KIND_TRAIT => "Trait: {$node->getName()}",
                 default => ucfirst($node->getKind()) . ($node->getName() ? ': ' . $node->getName() : ''),
             };
         }

--- a/tests/Unit/Service/Registrar/IssueSupporterTest.php
+++ b/tests/Unit/Service/Registrar/IssueSupporterTest.php
@@ -16,7 +16,7 @@ namespace Aeliot\TodoRegistrar\Test\Unit\Service\Registrar;
 use Aeliot\TodoRegistrar\Service\ContextPath\ContextPathBuilderRegistry;
 use Aeliot\TodoRegistrar\Service\Registrar\AbstractGeneralIssueConfig;
 use Aeliot\TodoRegistrar\Service\Registrar\IssueSupporter;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Service/Registrar/Redmine/IssueFactoryTest.php
+++ b/tests/Unit/Service/Registrar/Redmine/IssueFactoryTest.php
@@ -20,7 +20,7 @@ use Aeliot\TodoRegistrar\Service\Registrar\Redmine\EntityResolver;
 use Aeliot\TodoRegistrar\Service\Registrar\Redmine\GeneralIssueConfig;
 use Aeliot\TodoRegistrar\Service\Registrar\Redmine\IssueFactory;
 use Aeliot\TodoRegistrar\Service\Registrar\Redmine\UserResolver;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Service/Registrar/Redmine/RedmineRegistrarTest.php
+++ b/tests/Unit/Service/Registrar/Redmine/RedmineRegistrarTest.php
@@ -17,7 +17,7 @@ use Aeliot\TodoRegistrar\Service\Registrar\Redmine\Issue;
 use Aeliot\TodoRegistrar\Service\Registrar\Redmine\IssueApiClient;
 use Aeliot\TodoRegistrar\Service\Registrar\Redmine\IssueFactory;
 use Aeliot\TodoRegistrar\Service\Registrar\Redmine\RedmineRegistrar;
-use Aeliot\TodoRegistrarContracts\TodoInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Service/RegistrarProviderTest.php
+++ b/tests/Unit/Service/RegistrarProviderTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Test\Unit\Service;
+
+use Aeliot\TodoRegistrar\Config;
+use Aeliot\TodoRegistrar\Service\File\Finder;
+use Aeliot\TodoRegistrar\Service\Registrar\RegistrarFactoryRegistry;
+use Aeliot\TodoRegistrar\Service\RegistrarProvider;
+use Aeliot\TodoRegistrar\Service\ValidatorFactory;
+use Aeliot\TodoRegistrar\Test\Stub\LegacyConfig;
+use Aeliot\TodoRegistrar\Test\Stub\NewStaticRegistrarFactory;
+use Aeliot\TodoRegistrar\Test\Stub\StaticRegistrarFactory;
+use Aeliot\TodoRegistrarContracts\GeneralConfigInterface as LegacyGeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarFactoryInterface as NewRegistrarFactoryInterface;
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface as NewRegistrarInterface;
+use Aeliot\TodoRegistrarContracts\RegistrarFactoryInterface as LegacyRegistrarFactoryInterface;
+use Aeliot\TodoRegistrarContracts\RegistrarInterface as LegacyRegistrarInterface;
+use Aeliot\TodoRegistrarContracts\Todo\TodoInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RegistrarProvider::class)]
+final class RegistrarProviderTest extends TestCase
+{
+    private RegistrarProvider $registrarProvider;
+
+    protected function setUp(): void
+    {
+        $registry = $this->createMock(RegistrarFactoryRegistry::class);
+        $this->registrarProvider = new RegistrarProvider($registry, ValidatorFactory::create());
+    }
+
+    /**
+     * @return iterable<string, array{0: class-string<NewRegistrarFactoryInterface|LegacyRegistrarFactoryInterface>}>
+     */
+    public static function customRegistrarFactoryClassProvider(): iterable
+    {
+        yield 'legacy factory interface' => [StaticRegistrarFactory::class];
+        yield 'new factory interface' => [NewStaticRegistrarFactory::class];
+    }
+
+    #[DataProvider('customRegistrarFactoryClassProvider')]
+    public function testGetRegistrarWithCustomFactoryClass(string $factoryClass): void
+    {
+        $config = $this->createConfig($factoryClass, ['ticket_key' => 'TEST-100']);
+
+        $registrar = $this->registrarProvider->getRegistrar($config);
+
+        self::assertRegistrarReturnsKey($registrar, 'TEST-100');
+    }
+
+    public function testGetRegistrarWithLegacyFactoryInstance(): void
+    {
+        $factory = new StaticRegistrarFactory();
+        $config = $this->createConfig($factory, ['ticket_key' => 'LEGACY-1']);
+
+        $registrar = $this->registrarProvider->getRegistrar($config);
+
+        self::assertRegistrarReturnsKey($registrar, 'LEGACY-1');
+    }
+
+    public function testGetRegistrarWithNewFactoryInstance(): void
+    {
+        $factory = new NewStaticRegistrarFactory();
+        $config = $this->createConfig($factory, ['ticket_key' => 'NEW-1']);
+
+        $registrar = $this->registrarProvider->getRegistrar($config);
+
+        self::assertRegistrarReturnsKey($registrar, 'NEW-1');
+    }
+
+    public function testGetRegistrarWithLegacyGeneralConfig(): void
+    {
+        $config = (new LegacyConfig())
+            ->setFinder((new Finder())->in(__DIR__))
+            ->setRegistrar(StaticRegistrarFactory::class, ['ticket_key' => 'LEGACY-CFG-1']);
+
+        self::assertInstanceOf(LegacyGeneralConfigInterface::class, $config);
+
+        $registrar = $this->registrarProvider->getRegistrar($config);
+
+        self::assertRegistrarReturnsKey($registrar, 'LEGACY-CFG-1');
+    }
+
+    private static function assertRegistrarReturnsKey(
+        LegacyRegistrarInterface|NewRegistrarInterface $registrar,
+        string $expectedKey,
+    ): void {
+        $todo = self::createStub(TodoInterface::class);
+        self::assertSame($expectedKey, $registrar->register($todo));
+    }
+
+    /**
+     * @param class-string<NewRegistrarFactoryInterface|LegacyRegistrarFactoryInterface>|NewRegistrarFactoryInterface|LegacyRegistrarFactoryInterface $registrarType
+     * @param array<string, mixed> $registrarConfig
+     */
+    private function createConfig(
+        string|NewRegistrarFactoryInterface|LegacyRegistrarFactoryInterface $registrarType,
+        array $registrarConfig,
+    ): Config {
+        return (new Config())
+            ->setFinder((new Finder())->in(__DIR__))
+            ->setRegistrar($registrarType, $registrarConfig);
+    }
+}


### PR DESCRIPTION
1. Updated [aeliot/todo-registrar-contracts](https://github.com/Aeliot-Tm/todo-registrar-contracts) to version 2.3.0
2. Refactor to use new interfaces except: `RegistrarFactoryInterface`, `RegistrarInterface`.

Most users of the project will be able to update their php-configs and be ready for next major version.
> The only `RegistrarInterface` and `RegistrarFactoryInterface` cannot be overridden flexible and will be a tech debt.

**NOTE:**
1. Use YAML version of config. It makes migration to new versions more flexible. Read [documentation](https://github.com/Aeliot-Tm/todo-registrar/blob/main/docs/config/general_config_yaml.md).
2. Use [GitHub Action: TODO Registrar](https://github.com/marketplace/actions/todo-registrar) or [Docker container](https://github.com/Aeliot-Tm/todo-registrar/blob/main/README.md#using-of-docker-container)