### PR TITLE
Implement configuration of file extensions to finder and their aliases

### DIFF
--- a/.cursor/docs/Architecture/ProcessingFlow.md
+++ b/.cursor/docs/Architecture/ProcessingFlow.md
@@ -85,7 +85,9 @@ This document describes the main algorithm of TODO comment processing — from f
 
 **Class:** `Service\File\Finder` (implements `FinderInterface`)
 
-The Finder iterates over PHP files in configured directories using Symfony Finder.
+The Finder iterates over files in configured directories using Symfony Finder.
+In YAML config, masks come from `paths.extensions`, `paths.name`, or defaults (`php`, `yaml`, `yml`).
+In PHP config, masks are set on Finder directly (for example `->name('/\.(?:php|yaml|yml)$/')`).
 
 ```php
 foreach ($this->finder as $file) {
@@ -94,15 +96,20 @@ foreach ($this->finder as $file) {
 ```
 
 Configuration determines:
-- Which directories to scan
-- File patterns to include/exclude
+- Which directories to scan (`paths.in`, `in()` on Finder)
+- File patterns to include/exclude (`paths.extensions`, `paths.name`, `exclude`)
 - Recursion depth
 
 ### Step 2: File Tokenization
 
-**Class:** `Service\File\Parser\PhpFileParser`
+**Class:** `Service\File\FileParserRegistry` and parsers (`PhpFileParser`, `YamlFileParser`, …)
 
-Each file is tokenized using PHP's built-in tokenizer and wrapped in `TokenInterface`:
+`HeapRunner` resolves the parser by file extension. If `process.extensionAliases` maps a suffix to another key
+(for example `module` → `php`), that key is used to select the parser.
+
+**Class:** `Service\File\Parser\PhpFileParser` (for `php` and aliased PHP-like extensions)
+
+Each PHP file is tokenized using PHP's built-in tokenizer and wrapped in `TokenInterface`:
 
 ```php
 $phpTokens = PhpToken::tokenize(file_get_contents($file->getPathname()));

--- a/composer.lock
+++ b/composer.lock
@@ -58,12 +58,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Aeliot-Tm/todo-registrar-contracts.git",
-                "reference": "39c5b6935b59ff82e1dd42ef012e9767e99db915"
+                "reference": "4dedb82b09e247b35fe51a242d4dfb1ee09716af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Aeliot-Tm/todo-registrar-contracts/zipball/39c5b6935b59ff82e1dd42ef012e9767e99db915",
-                "reference": "39c5b6935b59ff82e1dd42ef012e9767e99db915",
+                "url": "https://api.github.com/repos/Aeliot-Tm/todo-registrar-contracts/zipball/4dedb82b09e247b35fe51a242d4dfb1ee09716af",
+                "reference": "4dedb82b09e247b35fe51a242d4dfb1ee09716af",
                 "shasum": ""
             },
             "require": {
@@ -102,7 +102,7 @@
                 "issues": "https://github.com/Aeliot-Tm/todo-registrar-contracts/issues",
                 "source": "https://github.com/Aeliot-Tm/todo-registrar-contracts/tree/rc3.0.0"
             },
-            "time": "2026-06-01T16:37:01+00:00"
+            "time": "2026-06-03T15:02:58+00:00"
         },
         {
             "name": "aeliot/yaml-token",

--- a/docs/config/general_config_php.md
+++ b/docs/config/general_config_php.md
@@ -15,7 +15,7 @@ use Aeliot\TodoRegistrar\Config;
 use Aeliot\TodoRegistrar\Service\File\Finder;
 
 return (new Config())
-    ->setFinder((new Finder())->in(__DIR__))
+    ->setFinder((new Finder())->name('/\.(?:php|yaml|yml)$/')->in(__DIR__))
     ->setRegistrar('JIRA', [
         'issue' => [
             'projectKey' => 'TODO',
@@ -50,7 +50,8 @@ For others read [customization](../customization.md) section.
 Pass instance of `Aeliot\TodoRegistrarContracts\FinderInterface` to method `setFinder`.
 If you use implementation from this project (`Aeliot\TodoRegistrar\Service\File\Finder`)
 then read documentation of [Symfony Finder](https://symfony.com/doc/current/components/finder.html).
-It has the same configuration.
+It has the same configuration: configure file masks with `name()`, directories with `in()`, and so on.
+In YAML config, `paths.extensions` and `paths.name` are applied to Finder automatically; in PHP config you set Finder yourself.
 
 ### Setting of Registrar
 
@@ -83,7 +84,7 @@ Don't wary about case of tags. They will be found in case-insensitive mode.
 
 ### Setting of Process Config
 
-Configure how TODO comments are processed:
+Configure run options (comment gluing, extension aliases for parsers, and so on):
 
 ```php
 use Aeliot\TodoRegistrar\Config;
@@ -92,11 +93,22 @@ use Aeliot\TodoRegistrar\Dto\GeneralConfig\ProcessConfig;
 $processConfig = new ProcessConfig();
 $processConfig->setGlueSameTickets(true);
 $processConfig->setGlueSequentialComments(true);
+$processConfig->setExtensionAliases([
+    'module' => 'php',
+    'inc' => 'php',
+]);
 
 return (new Config())
     // ...
     ->setProcessConfig($processConfig);
 ```
+
+#### Option extensionAliases
+
+**Type:** `array<string, string>`
+
+Maps file extension on disk to parser key (`php`, `yaml`, `yml`). Finder masks are configured separately via `setFinder()`.
+For a `.module` file you must both scan it in Finder and add `'module' => 'php'` in `extensionAliases`.
 
 #### Option glueSequentialComments
 

--- a/docs/config/general_config_yaml.md
+++ b/docs/config/general_config_yaml.md
@@ -21,6 +21,16 @@ paths:                            # Required. Defines paths which will be walked
                                   #           of directories.
     - tests/fixtures
     - var
+  extensions:                     # Optional. File extensions to scan (without leading dot).
+                                  #           Accepts string (one extension) or array of strings.
+                                  #           When omitted together with "name", defaults to php, yaml, yml.
+    - php
+    - module
+    - yaml
+    - yml
+  name: '/\.(?:php|module)$/'     # Optional. Symfony Finder name pattern(s).
+                                  #           Accepts string or array of strings. Can be used together with
+                                  #           "extensions". Responsibility for a valid pattern is on you.
 
 registrar:                        # Required. Configuration of Registrar
   type: GitHub                    # Required. Type of supported issue tracker or fully qualified class of custom factory
@@ -48,6 +58,9 @@ process:                          # Optional. Processing options
                                   #           Default: false.
     glueSequentialComments: true  # Optional. Glue consecutive single-line comments (// or #) into one multi-line comment.
                                   #           Default: false. Useful for YAML files and multi-line TODO descriptions.
+    extensionAliases:             # Optional. Map file extension on disk to parser key (e.g. php, yaml, yml).
+      module: php                 # Does not affect Finder; list extensions in paths.extensions or paths.name too.
+      inc: php
 ```
 
 ### Registrar options
@@ -204,7 +217,26 @@ docker run --rm --env-file .env -v "$(pwd):/app" ghcr.io/aeliot-tm/todo-registra
 
 ### Process options
 
-The `process` section configures how TODO comments are processed before extraction and registration.
+The `process` section configures how files and TODO comments are processed during a run.
+
+#### Option extensionAliases
+
+**Type:** `array` (map of string to string)
+
+Maps a file extension (without dot) to a built-in parser key: `php`, `yaml`, or `yml`.
+Used when choosing a file parser after discovery. It does **not** add files to the scan:
+include non-standard extensions in `paths.extensions` or `paths.name` as well.
+
+**Example:**
+
+```yaml
+paths:
+  in: src
+  extensions: [php, module]
+process:
+  extensionAliases:
+    module: php
+```
 
 #### Option glueSameTickets
 

--- a/examples/GitHub/.todo-registrar.php
+++ b/examples/GitHub/.todo-registrar.php
@@ -16,7 +16,7 @@ use Aeliot\TodoRegistrar\Enum\RegistrarType;
 use Aeliot\TodoRegistrar\Service\File\Finder;
 
 return (new Config())
-    ->setFinder((new Finder())->in(__DIR__))
+    ->setFinder((new Finder())->name('/\.(?:php|yaml|yml)$/')->in(__DIR__))
     ->setRegistrar(RegistrarType::GitHub, [
         'issue' => [
             'addTagToLabels' => true,

--- a/examples/GitLab/.todo-registrar.php
+++ b/examples/GitLab/.todo-registrar.php
@@ -16,7 +16,7 @@ use Aeliot\TodoRegistrar\Enum\RegistrarType;
 use Aeliot\TodoRegistrar\Service\File\Finder;
 
 return (new Config())
-    ->setFinder((new Finder())->in(dirname(__DIR__, 2).'/src/Service/Registrar/GitLab'))
+    ->setFinder((new Finder())->name('/\.(?:php|yaml|yml)$/')->in(dirname(__DIR__, 2).'/src/Service/Registrar/GitLab'))
     ->setRegistrar(RegistrarType::GitLab, [
         'issue' => [
             // Use either <project id> (more efficient) or <project path> (mode readable)

--- a/examples/JIRA/.todo-registrar.php
+++ b/examples/JIRA/.todo-registrar.php
@@ -16,7 +16,7 @@ use Aeliot\TodoRegistrar\Enum\RegistrarType;
 use Aeliot\TodoRegistrar\Service\File\Finder;
 
 return (new Config())
-    ->setFinder((new Finder())->in(__DIR__))
+    ->setFinder((new Finder())->name('/\.(?:php|yaml|yml)$/')->in(__DIR__))
     ->setRegistrar(RegistrarType::JIRA, [
         'issue' => [
             'projectKey' => 'Todo',

--- a/examples/Redmine/.todo-registrar.php
+++ b/examples/Redmine/.todo-registrar.php
@@ -16,7 +16,7 @@ use Aeliot\TodoRegistrar\Enum\RegistrarType;
 use Aeliot\TodoRegistrar\Service\File\Finder;
 
 return (new Config())
-    ->setFinder((new Finder())->in(__DIR__))
+    ->setFinder((new Finder())->name('/\.(?:php|yaml|yml)$/')->in(__DIR__))
     ->setRegistrar(RegistrarType::Redmine, [
         'issue' => [
             'addTagToLabels' => false,

--- a/examples/YandexTracker/.todo-registrar.php
+++ b/examples/YandexTracker/.todo-registrar.php
@@ -9,6 +9,7 @@ use Aeliot\TodoRegistrar\Service\File\Finder;
 return (new Config())
     ->setFinder(
         (new Finder())
+            ->name('/\.(?:php|yaml|yml)$/')
             ->in(dirname(__DIR__, 2))
             ->exclude(['vendor', 'var', 'tests'])
     )

--- a/src/Dto/GeneralConfig/PathsConfig.php
+++ b/src/Dto/GeneralConfig/PathsConfig.php
@@ -22,6 +22,11 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 final class PathsConfig
 {
+    /**
+     * @var string[]
+     */
+    public const DEFAULT_EXTENSIONS = ['php', 'yaml', 'yml'];
+
     #[Assert\AtLeastOneOf(
         constraints: [
             new Assert\IsNull(),
@@ -51,6 +56,19 @@ final class PathsConfig
     #[Assert\AtLeastOneOf(
         constraints: [
             new Assert\IsNull(),
+            new Assert\Type(type: 'string', message: 'Option "paths.extensions" must be a string or array of strings'),
+            new Assert\Sequentially(constraints: [
+                new Assert\Type(type: 'array', message: 'Option "paths.extensions" must be a string or array of strings'),
+                new Assert\All(constraints: [new Assert\Type(type: 'string', message: 'Each extension in "paths.extensions" must be a string')]),
+            ]),
+        ],
+        message: 'Option "paths.extensions" must be a string or array of strings'
+    )]
+    private mixed $extensions = null;
+
+    #[Assert\AtLeastOneOf(
+        constraints: [
+            new Assert\IsNull(),
             new Assert\Type(type: 'string', message: 'Option "paths.in" must be a string or array of strings'),
             new Assert\Sequentially(constraints: [
                 new Assert\Type(type: 'array', message: 'Option "paths.in" must be a string or array of strings'),
@@ -60,6 +78,19 @@ final class PathsConfig
         message: 'Option "paths.in" must be a string or array of strings'
     )]
     private mixed $in = null;
+
+    #[Assert\AtLeastOneOf(
+        constraints: [
+            new Assert\IsNull(),
+            new Assert\Type(type: 'string', message: 'Option "paths.name" must be a string or array of strings'),
+            new Assert\Sequentially(constraints: [
+                new Assert\Type(type: 'array', message: 'Option "paths.name" must be a string or array of strings'),
+                new Assert\All(constraints: [new Assert\Type(type: 'string', message: 'Each pattern in "paths.name" must be a string')]),
+            ]),
+        ],
+        message: 'Option "paths.name" must be a string or array of strings'
+    )]
+    private mixed $name = null;
 
     #[Assert\IsNull(message: 'Unknown "paths" options detected: {{ value }}')]
     private mixed $invalidKeys = null;
@@ -72,8 +103,10 @@ final class PathsConfig
         $this->in = $options['in'] ?? null;
         $this->append = $options['append'] ?? null;
         $this->exclude = $options['exclude'] ?? null;
+        $this->extensions = $options['extensions'] ?? null;
+        $this->name = $options['name'] ?? null;
 
-        $knownKeys = ['in', 'append', 'exclude'];
+        $knownKeys = ['append', 'exclude', 'extensions', 'in', 'name'];
         $unknownKeys = array_diff(array_keys($options), $knownKeys);
         if ($unknownKeys) {
             $this->invalidKeys = implode(', ', $unknownKeys);
@@ -89,11 +122,27 @@ final class PathsConfig
     }
 
     /**
+     * @return string[]
+     */
+    public function getExtensions(): array
+    {
+        return (array) ($this->extensions ?? []);
+    }
+
+    /**
      * @return string|string[]|null
      */
     public function getIn(): string|array|null
     {
         return $this->in;
+    }
+
+    /**
+     * @return string|string[]|null
+     */
+    public function getName(): string|array|null
+    {
+        return $this->name;
     }
 
     /**

--- a/src/Dto/GeneralConfig/ProcessArrayConfig.php
+++ b/src/Dto/GeneralConfig/ProcessArrayConfig.php
@@ -20,6 +20,25 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 final class ProcessArrayConfig
 {
+    /**
+     * @phpstan-var array<string,string>
+     */
+    #[Assert\Sequentially(constraints: [
+        new Assert\Type(type: 'array', message: 'Option "process.extensionAliases" must be an array'),
+        new Assert\All(constraints: [
+            new Assert\Type(type: 'string', message: 'Each extension alias must be a string'),
+        ]),
+    ])]
+    private mixed $extensionAliases;
+
+    /**
+     * @phpstan-var array<int|string>
+     */
+    #[Assert\All(constraints: [
+        new Assert\Type(type: 'string', message: 'Each key of option "process.extensionAliases" must be a string'),
+    ])]
+    protected array $extensionAliasesKeys = [];
+
     #[Assert\Type(type: 'bool', message: 'Option "process.glueSameTickets" must be a boolean')]
     private mixed $glueSameTickets;
 
@@ -36,12 +55,25 @@ final class ProcessArrayConfig
     {
         $this->glueSameTickets = $options['glueSameTickets'] ?? false;
         $this->glueSequentialComments = $options['glueSequentialComments'] ?? false;
+        $this->extensionAliases = $options['extensionAliases'] ?? [];
 
-        $knownKeys = ['glueSameTickets', 'glueSequentialComments'];
+        if (\is_array($this->extensionAliases)) {
+            $this->extensionAliasesKeys = array_keys($this->extensionAliases);
+        }
+
+        $knownKeys = ['extensionAliases', 'glueSameTickets', 'glueSequentialComments'];
         $unknownKeys = array_diff(array_keys($options), $knownKeys);
         if ($unknownKeys) {
             $this->invalidKeys = implode(', ', $unknownKeys);
         }
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function getExtensionAliases(): array
+    {
+        return $this->extensionAliases;
     }
 
     public function isGlueSameTickets(): bool

--- a/src/Dto/GeneralConfig/ProcessConfig.php
+++ b/src/Dto/GeneralConfig/ProcessConfig.php
@@ -20,8 +20,29 @@ final class ProcessConfig implements ProcessConfigInterface
     public const DEFAULT_GLUE_SAME_TICKETS = false;
     public const DEFAULT_GLUE_SEQUENTIAL_COMMENTS = false;
 
+    /**
+     * @var array<string, string>
+     */
+    private array $extensionAliases = [];
+
     private bool $glueSameTickets = self::DEFAULT_GLUE_SAME_TICKETS;
     private bool $glueSequentialComments = self::DEFAULT_GLUE_SEQUENTIAL_COMMENTS;
+
+    /**
+     * @return array<string, string>
+     */
+    public function getExtensionAliases(): array
+    {
+        return $this->extensionAliases;
+    }
+
+    /**
+     * @param array<string, string> $extensionAliases
+     */
+    public function setExtensionAliases(array $extensionAliases): void
+    {
+        $this->extensionAliases = $extensionAliases;
+    }
 
     public function isGlueSameTicket(): bool
     {

--- a/src/Service/Config/ArrayConfigFactory.php
+++ b/src/Service/Config/ArrayConfigFactory.php
@@ -20,6 +20,7 @@ use Aeliot\TodoRegistrar\Dto\GeneralConfig\PathsConfig;
 use Aeliot\TodoRegistrar\Dto\GeneralConfig\ProcessConfig;
 use Aeliot\TodoRegistrar\Exception\ConfigValidationException;
 use Aeliot\TodoRegistrar\Service\File\Finder;
+use Aeliot\TodoRegistrar\Service\File\FinderNamePatternBuilder;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -28,6 +29,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 final readonly class ArrayConfigFactory
 {
     public function __construct(
+        private FinderNamePatternBuilder $finderNamePatternBuilder,
         private ValidatorInterface $validator,
     ) {
     }
@@ -82,6 +84,7 @@ final readonly class ArrayConfigFactory
             $processConfig = new ProcessConfig();
             $processConfig->setGlueSameTickets($processDto->isGlueSameTickets());
             $processConfig->setGlueSequentialComments($processDto->isGlueSequentialComments());
+            $processConfig->setExtensionAliases($processDto->getExtensionAliases());
             $config->setProcessConfig($processConfig);
         }
 
@@ -120,6 +123,20 @@ final readonly class ArrayConfigFactory
         $exclude = $pathsConfig?->getExclude();
         if ($exclude) {
             $finder->exclude((array) $exclude);
+        }
+
+        $name = $pathsConfig?->getName();
+        if ($name) {
+            $finder->name($name);
+        }
+
+        $extensions = $pathsConfig?->getExtensions();
+        if (!$extensions && !$name) {
+            $extensions = PathsConfig::DEFAULT_EXTENSIONS;
+        }
+
+        if ($extensions) {
+            $finder->name($this->finderNamePatternBuilder->buildFromExtensions($extensions));
         }
 
         return $finder;

--- a/src/Service/File/FileParserRegistry.php
+++ b/src/Service/File/FileParserRegistry.php
@@ -27,9 +27,8 @@ final readonly class FileParserRegistry
     ) {
     }
 
-    public function findParser(\SplFileInfo $file): ?FileParserInterface
+    public function findParser(string $extension): ?FileParserInterface
     {
-        $extension = strtolower($file->getExtension());
         if (!$this->parsers->has($extension)) {
             return null;
         }

--- a/src/Service/File/Finder.php
+++ b/src/Service/File/Finder.php
@@ -24,7 +24,6 @@ class Finder extends SymfonyFinder implements FinderInterface
 
         $this
             ->files()
-            ->name('/\.(?:php|yaml|yml)$/')
             ->exclude('vendor');
     }
 }

--- a/src/Service/File/FinderNamePatternBuilder.php
+++ b/src/Service/File/FinderNamePatternBuilder.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Service\File;
+
+/**
+ * @internal
+ */
+final readonly class FinderNamePatternBuilder
+{
+    /**
+     * @param string[] $extensions
+     */
+    public function buildFromExtensions(array $extensions): string
+    {
+        $quoted = array_map(static fn (string $extension): string => preg_quote($extension, '/'), $extensions);
+
+        return '/\.(?:' . implode('|', $quoted) . ')$/';
+    }
+}

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -98,6 +98,16 @@ final readonly class HeapRunner
     }
 
     /**
+     * @return array<string, string>
+     */
+    private function getExtensionAliases(): array
+    {
+        return array_map('strtolower', ($this->config instanceof ProcessConfigAwareInterface
+            ? $this->config->getProcessConfig()?->getExtensionAliases()
+            : null) ?? []);
+    }
+
+    /**
      * @return \Generator<FileHeap>
      *
      * @throws FileReadException
@@ -105,10 +115,13 @@ final readonly class HeapRunner
      */
     private function getFileHeaps(ProcessStatistic $statistic): \Generator
     {
+        $extensionAliases = $this->getExtensionAliases();
         $glueSequentialComments = $this->getGlueSequentialComments();
 
         foreach ($this->finder as $file) {
-            $fileParser = $this->fileParserRegistry->findParser($file);
+            $extension = strtolower($file->getExtension());
+            $extensionAlias = $extensionAliases[$extension] ?? $extension;
+            $fileParser = $this->fileParserRegistry->findParser($extensionAlias);
             if (!$fileParser) {
                 $this->output->writeErr("There is not configured parser for file: {$file->getPathname()}", OutputAdapter::VERBOSITY_NORMAL);
                 continue;

--- a/tests/Functional/GlueSameTicketsTest.php
+++ b/tests/Functional/GlueSameTicketsTest.php
@@ -113,7 +113,7 @@ use Aeliot\TodoRegistrar\Service\File\Finder;
 \$processConfig->setGlueSameTickets({$glueSameTicketsStr});
 
 return (new Config())
-    ->setFinder((new Finder())->in('{$this->tempDir}'))
+    ->setFinder((new Finder())->name('/\.(?:php|yaml|yml)$/')->in('{$this->tempDir}'))
     ->setRegistrar('{$stubFactoryClass}', ['prefix' => 'KEY'])
     ->setProcessConfig(\$processConfig);
 

--- a/tests/Functional/RegisterCommandTest.php
+++ b/tests/Functional/RegisterCommandTest.php
@@ -221,7 +221,7 @@ use Aeliot\TodoRegistrar\Config;
 use Aeliot\TodoRegistrar\Service\File\Finder;
 
 return (new Config())
-    ->setFinder((new Finder())->in('{$this->tempDir}'))
+    ->setFinder((new Finder())->name('/\.(?:php|yaml|yml)$/')->in('{$this->tempDir}'))
     ->setRegistrar('{$stubFactoryClass}', [
         'ticket_key' => '{$ticketKey}',
     ]);

--- a/tests/Unit/ConfigFactoryTest.php
+++ b/tests/Unit/ConfigFactoryTest.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Test\Unit;
 
 use Aeliot\EnvResolver\Service\StringProcessor;
+use Aeliot\TodoRegistrar\Dto\GeneralConfig\PathsConfig;
 use Aeliot\TodoRegistrar\Service\Config\ArrayConfigFactory;
 use Aeliot\TodoRegistrar\Service\Config\ConfigFactory;
 use Aeliot\TodoRegistrar\Service\Config\YamlParser;
+use Aeliot\TodoRegistrar\Service\File\FinderNamePatternBuilder;
 use Aeliot\TodoRegistrar\Service\ValidatorFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -31,7 +33,7 @@ final class ConfigFactoryTest extends TestCase
     {
         $validator = ValidatorFactory::create();
         $config = (new ConfigFactory(
-            new ArrayConfigFactory($validator),
+            new ArrayConfigFactory(new FinderNamePatternBuilder(), $validator),
             new YamlParser(new StringProcessor()))
         )->create(__DIR__ . '/../fixtures/config/simple_config.yaml');
 
@@ -66,5 +68,10 @@ final class ConfigFactoryTest extends TestCase
             $propertyIterators->getValue($finder),
         )));
         self::assertSame(['bin/todo-registrar'], $appends);
+
+        $propertyNames = $reflection->getProperty('names');
+        $propertyNames->setAccessible(true);
+        $expected = (new FinderNamePatternBuilder())->buildFromExtensions(PathsConfig::DEFAULT_EXTENSIONS);
+        self::assertContains($expected, $propertyNames->getValue($finder));
     }
 }

--- a/tests/Unit/Dto/GeneralConfig/ArrayConfigTest.php
+++ b/tests/Unit/Dto/GeneralConfig/ArrayConfigTest.php
@@ -182,6 +182,46 @@ final class ArrayConfigTest extends TestCase
                 'registrar' => ['type' => 'github'],
             ],
         ];
+
+        yield 'paths.extensions as string' => [
+            [
+                'paths' => ['extensions' => 'php'],
+                'registrar' => ['type' => 'github'],
+            ],
+        ];
+
+        yield 'paths.extensions as array' => [
+            [
+                'paths' => ['extensions' => ['php', 'module']],
+                'registrar' => ['type' => 'github'],
+            ],
+        ];
+
+        yield 'paths.name as string' => [
+            [
+                'paths' => ['name' => '/\.custom$/'],
+                'registrar' => ['type' => 'github'],
+            ],
+        ];
+
+        yield 'paths.name and extensions' => [
+            [
+                'paths' => [
+                    'name' => '/\.custom$/',
+                    'extensions' => ['php', 'module'],
+                ],
+                'registrar' => ['type' => 'github'],
+            ],
+        ];
+
+        yield 'process.extensionAliases' => [
+            [
+                'registrar' => ['type' => 'github'],
+                'process' => [
+                    'extensionAliases' => ['module' => 'php'],
+                ],
+            ],
+        ];
     }
 
     public static function getDataForTestMissingRequiredFields(): iterable
@@ -312,6 +352,26 @@ final class ArrayConfigTest extends TestCase
         yield 'process with unknown key' => [
             ['registrar' => ['type' => 'github'], 'process' => ['unknownOption' => true]],
             'Unknown "process" options detected',
+        ];
+
+        yield 'paths.extensions is int' => [
+            ['paths' => ['extensions' => 123], 'registrar' => ['type' => 'github']],
+            'Option "paths.extensions" must be a string or array of strings',
+        ];
+
+        yield 'paths.extensions array contains int' => [
+            ['paths' => ['extensions' => ['php', 123]], 'registrar' => ['type' => 'github']],
+            'Each extension in "paths.extensions" must be a string',
+        ];
+
+        yield 'paths.name is int' => [
+            ['paths' => ['name' => 123], 'registrar' => ['type' => 'github']],
+            'Option "paths.name" must be a string or array of strings',
+        ];
+
+        yield 'process.extensionAliases is string' => [
+            ['registrar' => ['type' => 'github'], 'process' => ['extensionAliases' => 'invalid']],
+            'Option "process.extensionAliases" must be an array',
         ];
     }
 

--- a/tests/Unit/Dto/GeneralConfig/ProcessArrayConfigTest.php
+++ b/tests/Unit/Dto/GeneralConfig/ProcessArrayConfigTest.php
@@ -41,6 +41,13 @@ final class ProcessArrayConfigTest extends TestCase
         self::assertCount(0, $violations);
     }
 
+    public function testDefaultExtensionAliases(): void
+    {
+        $config = new ProcessArrayConfig([]);
+
+        self::assertSame([], $config->getExtensionAliases());
+    }
+
     public function testDefaultValue(): void
     {
         $config = new ProcessArrayConfig([]);
@@ -65,6 +72,36 @@ final class ProcessArrayConfigTest extends TestCase
         yield 'array' => [[], 'Option "process.glueSequentialComments" must be a boolean'];
     }
 
+    public function testInvalidExtensionAliasesType(): void
+    {
+        $config = new ProcessArrayConfig(['extensionAliases' => 'invalid']);
+        $violations = self::$validator->validate($config);
+
+        self::assertGreaterThan(0, \count($violations));
+        $messages = array_map(static fn ($v) => $v->getMessage(), iterator_to_array($violations));
+        self::assertContains('Option "process.extensionAliases" must be an array', $messages);
+    }
+
+    public function testInvalidExtensionAliasValueType(): void
+    {
+        $config = new ProcessArrayConfig(['extensionAliases' => ['module' => 123]]);
+        $violations = self::$validator->validate($config);
+
+        self::assertGreaterThan(0, \count($violations));
+        $messages = array_map(static fn ($v) => $v->getMessage(), iterator_to_array($violations));
+        self::assertContains('Each extension alias must be a string', $messages);
+    }
+
+    public function testInvalidExtensionAliasKeyType(): void
+    {
+        $config = new ProcessArrayConfig(['extensionAliases' => [123 => 'php']]);
+        $violations = self::$validator->validate($config);
+
+        self::assertGreaterThan(0, \count($violations));
+        $messages = array_map(static fn ($v) => $v->getMessage(), iterator_to_array($violations));
+        self::assertContains('Each key of option "process.extensionAliases" must be a string', $messages);
+    }
+
     public function testUnknownKeys(): void
     {
         $config = new ProcessArrayConfig(['glueSequentialComments' => true, 'unknownKey' => 'value']);
@@ -80,5 +117,17 @@ final class ProcessArrayConfigTest extends TestCase
             }
         }
         self::assertTrue($found, 'Expected unknown keys error message');
+    }
+
+    public function testValidExtensionAliases(): void
+    {
+        $config = new ProcessArrayConfig([
+            'extensionAliases' => ['module' => 'php', 'inc' => 'php'],
+        ]);
+
+        self::assertSame(['module' => 'php', 'inc' => 'php'], $config->getExtensionAliases());
+
+        $violations = self::$validator->validate($config);
+        self::assertCount(0, $violations);
     }
 }

--- a/tests/Unit/Dto/GeneralConfig/ProcessConfigTest.php
+++ b/tests/Unit/Dto/GeneralConfig/ProcessConfigTest.php
@@ -24,6 +24,16 @@ final class ProcessConfigTest extends TestCase
     {
         $config = new ProcessConfig();
         self::assertFalse($config->isGlueSequentialComments());
+        self::assertSame([], $config->getExtensionAliases());
+    }
+
+    public function testExtensionAliasesGetterSetter(): void
+    {
+        $config = new ProcessConfig();
+        $aliases = ['module' => 'php', 'inc' => 'php'];
+        $config->setExtensionAliases($aliases);
+
+        self::assertSame($aliases, $config->getExtensionAliases());
     }
 
     public function testGetterSetter(): void

--- a/tests/Unit/Service/Config/ArrayConfigFactoryValidationTest.php
+++ b/tests/Unit/Service/Config/ArrayConfigFactoryValidationTest.php
@@ -14,10 +14,15 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Test\Unit\Service\Config;
 
 use Aeliot\TodoRegistrar\Dto\GeneralConfig\ArrayConfig;
+use Aeliot\TodoRegistrar\Dto\GeneralConfig\PathsConfig;
+use Aeliot\TodoRegistrar\Dto\GeneralConfig\ProcessConfig;
 use Aeliot\TodoRegistrar\Exception\ConfigValidationException;
 use Aeliot\TodoRegistrar\Service\Config\ArrayConfigFactory;
+use Aeliot\TodoRegistrar\Service\File\Finder;
+use Aeliot\TodoRegistrar\Service\File\FinderNamePatternBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder as SymfonyFinder;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -34,9 +39,20 @@ final class ArrayConfigFactoryValidationTest extends TestCase
             ->getValidator();
     }
 
+    public function testCreateAppliesDefaultExtensionsPattern(): void
+    {
+        $config = $this->createFactory()->create([
+            'paths' => ['in' => __DIR__],
+            'registrar' => ['type' => 'github', 'options' => []],
+        ]);
+
+        $expected = (new FinderNamePatternBuilder())->buildFromExtensions(PathsConfig::DEFAULT_EXTENSIONS);
+        self::assertContains($expected, $this->getFinderNames($config->getFinder()));
+    }
+
     public function testCreateWithValidConfig(): void
     {
-        $factory = new ArrayConfigFactory(self::$validator);
+        $factory = $this->createFactory();
         $options = [
             'paths' => ['in' => __DIR__],
             'registrar' => ['type' => 'github', 'options' => ['service' => ['token' => 'xxx']]],
@@ -49,7 +65,7 @@ final class ArrayConfigFactoryValidationTest extends TestCase
 
     public function testCreateThrowsOnMissingRegistrar(): void
     {
-        $factory = new ArrayConfigFactory(self::$validator);
+        $factory = $this->createFactory();
         $options = [
             'paths' => ['in' => '/path'],
         ];
@@ -61,7 +77,7 @@ final class ArrayConfigFactoryValidationTest extends TestCase
 
     public function testCreateThrowsOnInvalidRegistrarType(): void
     {
-        $factory = new ArrayConfigFactory(self::$validator);
+        $factory = $this->createFactory();
         $options = [
             'paths' => ['in' => '/path'],
             'registrar' => ['type' => 123],
@@ -74,7 +90,7 @@ final class ArrayConfigFactoryValidationTest extends TestCase
 
     public function testCreateThrowsOnUnknownOptions(): void
     {
-        $factory = new ArrayConfigFactory(self::$validator);
+        $factory = $this->createFactory();
         $options = [
             'paths' => ['in' => '/path'],
             'registrar' => ['type' => 'github'],
@@ -86,9 +102,75 @@ final class ArrayConfigFactoryValidationTest extends TestCase
         $factory->create($options);
     }
 
+    public function testCreateWithExtensionAliases(): void
+    {
+        $config = $this->createFactory()->create([
+            'paths' => ['in' => __DIR__],
+            'registrar' => ['type' => 'github', 'options' => []],
+            'process' => [
+                'extensionAliases' => ['module' => 'php'],
+            ],
+        ]);
+
+        $processConfig = $config->getProcessConfig();
+        self::assertInstanceOf(ProcessConfig::class, $processConfig);
+        self::assertSame(['module' => 'php'], $processConfig->getExtensionAliases());
+    }
+
+    public function testCreateWithPathsExtensions(): void
+    {
+        $config = $this->createFactory()->create([
+            'paths' => ['in' => __DIR__, 'extensions' => ['php', 'module']],
+            'registrar' => ['type' => 'github', 'options' => []],
+        ]);
+
+        $expected = (new FinderNamePatternBuilder())->buildFromExtensions(['php', 'module']);
+        self::assertContains($expected, $this->getFinderNames($config->getFinder()));
+    }
+
+    public function testCreateWithPathsExtensionsAsString(): void
+    {
+        $config = $this->createFactory()->create([
+            'paths' => ['in' => __DIR__, 'extensions' => 'module'],
+            'registrar' => ['type' => 'github', 'options' => []],
+        ]);
+
+        $expected = (new FinderNamePatternBuilder())->buildFromExtensions(['module']);
+        self::assertContains($expected, $this->getFinderNames($config->getFinder()));
+    }
+
+    public function testCreateWithPathsName(): void
+    {
+        $config = $this->createFactory()->create([
+            'paths' => ['in' => __DIR__, 'name' => '/\.custom$/'],
+            'registrar' => ['type' => 'github', 'options' => []],
+        ]);
+
+        self::assertContains('/\.custom$/', $this->getFinderNames($config->getFinder()));
+    }
+
+    public function testCreateWithPathsNameAndExtensions(): void
+    {
+        $config = $this->createFactory()->create([
+            'paths' => [
+                'in' => __DIR__,
+                'name' => '/\.custom$/',
+                'extensions' => ['module'],
+            ],
+            'registrar' => ['type' => 'github', 'options' => []],
+        ]);
+
+        $names = $this->getFinderNames($config->getFinder());
+        self::assertContains('/\.custom$/', $names);
+        self::assertContains(
+            (new FinderNamePatternBuilder())->buildFromExtensions(['module']),
+            $names,
+        );
+    }
+
     public function testExceptionContainsAllViolations(): void
     {
-        $factory = new ArrayConfigFactory(self::$validator);
+        $factory = $this->createFactory();
         $options = []; // Missing all required fields
 
         try {
@@ -110,7 +192,7 @@ final class ArrayConfigFactoryValidationTest extends TestCase
 
     public function testCreateWithTags(): void
     {
-        $factory = new ArrayConfigFactory(self::$validator);
+        $factory = $this->createFactory();
         $options = [
             'paths' => ['in' => __DIR__],
             'registrar' => ['type' => 'github', 'options' => []],
@@ -124,7 +206,7 @@ final class ArrayConfigFactoryValidationTest extends TestCase
 
     public function testCreateWithoutTagsUsesDefault(): void
     {
-        $factory = new ArrayConfigFactory(self::$validator);
+        $factory = $this->createFactory();
         $options = [
             'paths' => ['in' => __DIR__],
             'registrar' => ['type' => 'github', 'options' => []],
@@ -134,5 +216,24 @@ final class ArrayConfigFactoryValidationTest extends TestCase
 
         // Default tags are set in Config class
         self::assertSame(['todo', 'fixme'], $config->getTags());
+    }
+
+    private function createFactory(): ArrayConfigFactory
+    {
+        return new ArrayConfigFactory(new FinderNamePatternBuilder(), self::$validator);
+    }
+
+    /**
+     * @param Finder $finder
+     *
+     * @return list<string|\Closure>
+     */
+    private function getFinderNames(SymfonyFinder $finder): array
+    {
+        $reflection = new \ReflectionClass(SymfonyFinder::class);
+        $property = $reflection->getProperty('names');
+        $property->setAccessible(true);
+
+        return $property->getValue($finder);
     }
 }

--- a/tests/Unit/Service/Config/ConfigProviderTest.php
+++ b/tests/Unit/Service/Config/ConfigProviderTest.php
@@ -25,6 +25,7 @@ use Aeliot\TodoRegistrar\Service\Config\ConfigFileGuesser;
 use Aeliot\TodoRegistrar\Service\Config\ConfigProvider;
 use Aeliot\TodoRegistrar\Service\Config\StdinConfigFactory;
 use Aeliot\TodoRegistrar\Service\Config\YamlParser;
+use Aeliot\TodoRegistrar\Service\File\FinderNamePatternBuilder;
 use Aeliot\TodoRegistrar\Service\ValidatorFactory;
 use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -50,7 +51,7 @@ final class ConfigProviderTest extends TestCase
             $absolutePathMaker,
             new ConfigFileGuesser($absolutePathMaker),
         );
-        $arrayConfigFactory = new ArrayConfigFactory(self::$validator);
+        $arrayConfigFactory = new ArrayConfigFactory(new FinderNamePatternBuilder(), self::$validator);
         $yamlParser = new YamlParser(new StringProcessor());
         $configFactory = new ConfigFactory($arrayConfigFactory, $yamlParser);
         $stdinConfigFactory = new StdinConfigFactory($arrayConfigFactory, $yamlParser);

--- a/tests/Unit/Service/File/FinderNamePatternBuilderTest.php
+++ b/tests/Unit/Service/File/FinderNamePatternBuilderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Test\Unit\Service\File;
+
+use Aeliot\TodoRegistrar\Service\File\FinderNamePatternBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FinderNamePatternBuilder::class)]
+final class FinderNamePatternBuilderTest extends TestCase
+{
+    public function testBuildFromExtensions(): void
+    {
+        $builder = new FinderNamePatternBuilder();
+
+        self::assertSame(
+            '/\.(?:php|yaml|yml)$/',
+            $builder->buildFromExtensions(['php', 'yaml', 'yml']),
+        );
+    }
+
+    public function testBuildFromExtensionsEscapesSpecialCharacters(): void
+    {
+        $builder = new FinderNamePatternBuilder();
+
+        self::assertSame(
+            '/\.(?:module|inc)$/',
+            $builder->buildFromExtensions(['module', 'inc']),
+        );
+    }
+}

--- a/tests/Unit/Service/File/FinderTest.php
+++ b/tests/Unit/Service/File/FinderTest.php
@@ -14,15 +14,18 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Test\Unit\Service\File;
 
 use Aeliot\TodoRegistrar\Service\File\Finder;
+use Aeliot\TodoRegistrar\Service\File\FinderNamePatternBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(Finder::class)]
+#[CoversClass(FinderNamePatternBuilder::class)]
 final class FinderTest extends TestCase
 {
     public function testFind(): void
     {
         $finder = (new Finder())
+            ->name((new FinderNamePatternBuilder())->buildFromExtensions(['php']))
             ->in(__DIR__ . '/../../../fixtures')
             ->notName('/\.(?:yaml|yml)$/')
             ->exclude(['config', 'comments_gluing', 'php', 'start_line'])

--- a/tests/Unit/Service/RegistrarProviderTest.php
+++ b/tests/Unit/Service/RegistrarProviderTest.php
@@ -63,7 +63,7 @@ final class RegistrarProviderTest extends TestCase
         array $registrarConfig,
     ): Config {
         return (new Config())
-            ->setFinder((new Finder())->in(__DIR__))
+            ->setFinder((new Finder())->name('/\.(?:php|yaml|yml)$/')->in(__DIR__))
             ->setRegistrar($registrarType, $registrarConfig);
     }
 }

--- a/tests/fixtures/config/invalid_config_missing_registrar.php
+++ b/tests/fixtures/config/invalid_config_missing_registrar.php
@@ -7,5 +7,5 @@ use Aeliot\TodoRegistrar\Service\File\Finder;
 
 // Invalid: missing setRegistrar() call
 return (new Config())
-    ->setFinder((new Finder())->in(__DIR__));
+    ->setFinder((new Finder())->name('/\.(?:php|yaml|yml)$/')->in(__DIR__));
 

--- a/tests/fixtures/config/valid_config.php
+++ b/tests/fixtures/config/valid_config.php
@@ -7,7 +7,7 @@ use Aeliot\TodoRegistrar\Enum\RegistrarType;
 use Aeliot\TodoRegistrar\Service\File\Finder;
 
 return (new Config())
-    ->setFinder((new Finder())->in(__DIR__))
+    ->setFinder((new Finder())->name('/\.(?:php|yaml|yml)$/')->in(__DIR__))
     ->setRegistrar(RegistrarType::GitHub, [
         'issue' => [
             'addTagToLabels' => true,


### PR DESCRIPTION
Added options:
```yaml
paths: 
  extensions:                     # Optional. File extensions to scan (without leading dot).
                                  #           Accepts string (one extension) or array of strings.
                                  #           When omitted together with "name", 
                                  #           defaults to: php, yaml, yml.
    - php
    - module
    - yaml
    - yml
  name: '/\.(?:php|module)$/'     # Optional. Symfony Finder name pattern(s).
                                  #           Accepts string or array of strings. Can be used
                                  #           together with "extensions".
                                  #           Responsibility for a valid pattern is on you.

process: 
    extensionAliases:             # Optional. Map file extension on disk to parser key
                                  #           (e.g. php, yaml, yml). Does not affect Finder; 
                                  #           list extensions in paths.extensions or paths.name too.
      module: php
      inc: php
```


Allow flexible parsing of files with not only standard extensions: `php`, `yaml`, `yml`.

Maps a file extension (without dot) to a built-in parser key `extensionAliases`.
Used when choosing a file parser after discovery. It does **not** add files to the scan:
include non-standard extensions in `paths.extensions` or `paths.name` as well.

**Example:**

```yaml
paths:
  in: src
  extensions: [php, module]
process:
  extensionAliases:
    module: php
```