### PR TITLE
Fix generation of label color for GitHub

### DIFF
--- a/src/Service/ColorGenerator.php
+++ b/src/Service/ColorGenerator.php
@@ -20,7 +20,7 @@ final class ColorGenerator
      * Uses hash of the name to ensure deterministic color generation.
      * Color values are in range 25% to 85% for each RGB channel.
      *
-     * @return string Hex color code (e.g., "#A1B2C3")
+     * @return string Hex color code without leading hash (e.g., "A1B2C3")
      */
     public function generateColor(string $name): string
     {
@@ -40,6 +40,6 @@ final class ColorGenerator
         $g = $minValue + (int) (($g / 255) * $range);
         $b = $minValue + (int) (($b / 255) * $range);
 
-        return \sprintf('#%02X%02X%02X', $r, $g, $b);
+        return \sprintf('%02X%02X%02X', $r, $g, $b);
     }
 }

--- a/src/Service/Registrar/GitLab/LabelApiClient.php
+++ b/src/Service/Registrar/GitLab/LabelApiClient.php
@@ -49,7 +49,7 @@ final readonly class LabelApiClient
         try {
             $this->projects->addLabel($project, [
                 'name' => $name,
-                'color' => $this->colorGenerator->generateColor($name),
+                'color' => '#' . $this->colorGenerator->generateColor($name),
             ]);
         } catch (ApiLimitExceededException $exception) {
             throw new LimitExceededException('Cannot create label case of GitLab API limit exceeded', 0, $exception);

--- a/tests/Unit/Service/ColorGeneratorTest.php
+++ b/tests/Unit/Service/ColorGeneratorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Test\Unit\Service;
+
+use Aeliot\TodoRegistrar\Service\ColorGenerator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ColorGenerator::class)]
+final class ColorGeneratorTest extends TestCase
+{
+    public function testGenerateColorIsDeterministic(): void
+    {
+        $generator = new ColorGenerator();
+
+        self::assertSame($generator->generateColor('bug'), $generator->generateColor('bug'));
+    }
+
+    public function testGenerateColorReturnsHexWithoutLeadingHash(): void
+    {
+        $color = (new ColorGenerator())->generateColor('feature');
+
+        self::assertMatchesRegularExpression('/^[0-9A-F]{6}$/', $color);
+    }
+}


### PR DESCRIPTION
Fix issue 
```shell
In GithubExceptionThrower.php line 94:
                                                                     
  Validation Failed: Field "color" is invalid, for resource "Label" 
```

**Reason:** GitHub accepts only hex-code as color of label without symbol `#`