### PR TITLE
Refactor processing flow (imperative flow)

### DIFF
--- a/.cursor/docs/Architecture/Overview.md
+++ b/.cursor/docs/Architecture/Overview.md
@@ -69,7 +69,8 @@ PHP config: `require` must return `GeneralConfigInterface`.
 | Class | Role |
 |---|---|
 | `FileHeapFactory` | Parses a file and builds `FileHeap` (parser lookup, optional sequential gluing) |
-| `HeapRunner` | Main loop: files → comments → todos → register → save |
+| `FileProcessor` | Processes one file: extract TODOs → register → inject key → save |
+| `HeapRunner` | Main loop over finder: create file heap, delegate to `FileProcessor`, handle errors |
 | `HeapContext` | Run-scoped state: statistic, hash→key map, glue flags, output |
 | `HeapRunnerFactory` | Wires dependencies from config |
 | `TodoBuilder` | Builds `Todo` DTO with hash and inline config |

--- a/.cursor/docs/Architecture/Overview.md
+++ b/.cursor/docs/Architecture/Overview.md
@@ -68,6 +68,7 @@ PHP config: `require` must return `GeneralConfigInterface`.
 | Class | Role |
 |---|---|
 | `HeapRunner` | Main loop: files → comments → todos → register → save |
+| `HeapContext` | Run-scoped state: statistic, hash→key map, glueSameTickets flag |
 | `HeapRunnerFactory` | Wires dependencies from config |
 | `TodoBuilder` | Builds `Todo` DTO with hash and inline config |
 

--- a/.cursor/docs/Architecture/Overview.md
+++ b/.cursor/docs/Architecture/Overview.md
@@ -57,7 +57,8 @@ PHP config: `require` must return `GeneralConfigInterface`.
 
 | Class | Role |
 |---|---|
-| `FileHeap` | Builds `CommentNode[]`, glues sequential comments via glue gates |
+| `CommentNodesBuilder` | Builds `CommentNode[]`, glues sequential comments via glue gates |
+| `FileHeap` | Per-file heap: lazy comment nodes, registration stats, save after register |
 | `SequentialCommentGlueGateRegistry` | PHP/YAML rules for sequential comment gluing |
 | `Comment/Extractor` | Splits comments into `CommentPart[]` |
 | `Tag/Detector` | Parses tag, assignee, existing key |

--- a/.cursor/docs/Architecture/Overview.md
+++ b/.cursor/docs/Architecture/Overview.md
@@ -68,8 +68,9 @@ PHP config: `require` must return `GeneralConfigInterface`.
 
 | Class | Role |
 |---|---|
+| `FileHeapFactory` | Parses a file and builds `FileHeap` (parser lookup, optional sequential gluing) |
 | `HeapRunner` | Main loop: files → comments → todos → register → save |
-| `HeapContext` | Run-scoped state: statistic, hash→key map, glueSameTickets flag |
+| `HeapContext` | Run-scoped state: statistic, hash→key map, glue flags, output |
 | `HeapRunnerFactory` | Wires dependencies from config |
 | `TodoBuilder` | Builds `Todo` DTO with hash and inline config |
 

--- a/.cursor/docs/Architecture/ProcessingFlow.md
+++ b/.cursor/docs/Architecture/ProcessingFlow.md
@@ -7,25 +7,29 @@ Main algorithm from file discovery to issue registration and source update. Impl
 ```
 HeapRunner.run()
     │
-    ├─► Finder (SplFileInfo)
+    ├─► HeapContext (ProcessStatistic, hashToKey, glueSameTickets)
     │
-    ├─► FileParserRegistry → ParsedFile (tokens + context map)
-    │
-    ├─► FileHeap.buildCommentNodes()  [optional sequential gluing]
-    │
-    ├─► Comment/Extractor → CommentPart[]
-    │       └─ skip if tag line has ticketKey
-    │
-    ├─► TodoBuilder → Todo
-    │
-    ├─► Registrar.register()  [optional same-ticket gluing by hash]
-    │
-    ├─► Todo.injectKey() → CommentPart updates token text
-    │
-    └─► Saver.save() via fileUpdateCallback
+    └─► foreach Finder (SplFileInfo)
+            │
+            ├─► createFileHeap()
+            │       ├─► FileParserRegistry → ParsedFile (tokens + context map)
+            │       └─► FileHeap.buildCommentNodes()  [optional sequential gluing]
+            │
+            ├─► processFile()
+            │       ├─► Comment/Extractor → CommentPart[]
+            │       │       └─ skip if tag line has ticketKey
+            │       ├─► TodoBuilder → Todo
+            │       ├─► Registrar.register()  [optional same-ticket gluing by hash]
+            │       ├─► Todo.injectKey() → CommentPart updates token text
+            │       └─► Saver.save() via fileUpdateCallback
+            │
+            ├─► logFileCompletion()
+            │
+            └─► on Exception: writeError() + rethrow (fail-fast)
 ```
 
-Processing uses generators: one file in memory at a time; file saved after each registration.
+One file in memory at a time; file saved after each registration. The main loop is imperative;
+generators are used only in local helpers (e.g. `Comment/Extractor::getLines()`).
 
 ## Step 1: File Discovery
 
@@ -116,6 +120,8 @@ Creates `ContextAwareTodo` (implements `Todo`):
 
 **Class:** `HeapRunner::register()`
 
+Run-scoped state lives in `HeapContext` (`statistic`, `hashToKey`, `glueSameTickets`).
+
 If `process.glueSameTickets` and hash seen → reuse key, `tickGluedTodo()`.
 Else → `registrar->register($todo)`, store hash → key mapping.
 
@@ -153,15 +159,52 @@ Tracks per run: analyzed/updated files, comment tokens, ignored/glued/registered
 
 Optional export via [Report](../Feature/Report.md).
 
-## Generator Chain
+## Processing Loop
 
 ```
 run()
-  └── getTodos()                 → [Todo, fileUpdateCallback]
-        └── getCommentParts()    → [CommentPart, fileUpdateCallback]
-              └── getFileHeaps() → FileHeap
-                    └── finder   → SplFileInfo
+  ├── new HeapContext
+  └── foreach finder → SplFileInfo
+        try
+          ├── createFileHeap()     → FileHeap (or skip if no parser)
+          ├── processFile()
+          │     └── foreach commentNode
+          │           └── foreach CommentPart
+          │                 ├── TodoBuilder → Todo
+          │                 ├── register() + fileUpdateCallback
+          │                 └── CommentRegistrationException propagates up
+          └── logFileCompletion()
+        catch Exception
+          ├── writeError($exception, $file)
+          └── rethrow
 ```
+
+Per-file processing is wrapped in a single `try/catch` in `run()`. Any `\Exception`
+(parse, glue gate, registration, todo building) triggers `writeError()` with the current
+file path and stops the run (fail-fast). `register()` wraps registrar failures in
+`CommentRegistrationException` before they reach the outer catch.
+
+## HeapContext
+
+**Class:** `Dto/HeapContext`
+
+Mutable run-scoped bag passed through `createFileHeap()`, `processFile()`, and `register()`:
+
+| Property | Purpose |
+|---|---|
+| `statistic` | `ProcessStatistic` for the whole run |
+| `hashToKey` | Hash → issue key map for same-ticket gluing |
+| `glueSameTickets` | From `process.glueSameTickets` config |
+
+Created once in `run()`; shared across all files in the run.
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| No parser for file extension | `writeErr`, skip file (`continue`) |
+| Parse / glue gate / registration / build error | `writeError($exception, $file)` in `run()`, rethrow |
+| Registrar failure | Wrapped in `CommentRegistrationException` in `register()` |
 
 ## Related Features
 

--- a/.cursor/docs/Architecture/ProcessingFlow.md
+++ b/.cursor/docs/Architecture/ProcessingFlow.md
@@ -13,7 +13,7 @@ HeapRunner.run()
             │
             ├─► createFileHeap()
             │       ├─► FileParserRegistry → ParsedFile (tokens + context map)
-            │       └─► FileHeap.buildCommentNodes()  [optional sequential gluing]
+            │       └─► CommentNodesBuilder.build()  [optional sequential gluing]
             │
             ├─► processFile()
             │       ├─► Comment/Extractor → CommentPart[]
@@ -21,7 +21,7 @@ HeapRunner.run()
             │       ├─► TodoBuilder → Todo
             │       ├─► Registrar.register()  [optional same-ticket gluing by hash]
             │       ├─► Todo.injectKey() → CommentPart updates token text
-            │       └─► Saver.save() via fileUpdateCallback
+            │       └─► FileHeap.saveAfterRegistration() → Saver.save()
             │
             ├─► logFileCompletion()
             │
@@ -64,7 +64,7 @@ See [Source File Parsing](../Feature/SourceFileParsing.md).
 
 ## Step 3: Comment Node Building
 
-**Classes:** `Dto/FileHeap`, `Service/Comment/SequentialCommentGlueGateRegistry`
+**Classes:** `Dto/FileHeap`, `Service/Comment/CommentNodesBuilder`, `Service/Comment/SequentialCommentGlueGateRegistry`
 
 Single pass via `ParsedFile::getTokenStream()`:
 
@@ -143,13 +143,13 @@ See [Issue Key Injection](../Feature/IssueKeyInjection.md).
 
 ## Step 9: Save File
 
-**Class:** `Service/File/Saver`
+**Classes:** `Dto/FileHeap`, `Service/File/Saver`
 
 ```php
 implode('', array_map(fn ($t) => $t->getText(), $tokens))
 ```
 
-Called from `FileHeap` closure after each successful registration for that file.
+`FileHeap::saveAfterRegistration()` updates per-file statistics and writes the file after each successful registration.
 
 ## Statistics
 
@@ -171,7 +171,7 @@ run()
           │     └── foreach commentNode
           │           └── foreach CommentPart
           │                 ├── TodoBuilder → Todo
-          │                 ├── register() + fileUpdateCallback
+          │                 ├── register() + saveAfterRegistration()
           │                 └── CommentRegistrationException propagates up
           └── logFileCompletion()
         catch Exception

--- a/.cursor/docs/Architecture/ProcessingFlow.md
+++ b/.cursor/docs/Architecture/ProcessingFlow.md
@@ -11,7 +11,7 @@ HeapRunner.run()
     │
     └─► foreach Finder (SplFileInfo)
             │
-            ├─► createFileHeap()
+            ├─► FileHeapFactory.create()
             │       ├─► FileParserRegistry → ParsedFile (tokens + context map)
             │       └─► CommentNodesBuilder.build()  [optional sequential gluing]
             │
@@ -166,7 +166,7 @@ run()
   ├── new HeapContext
   └── foreach finder → SplFileInfo
         try
-          ├── createFileHeap()     → FileHeap (or skip if no parser)
+          ├── FileHeapFactory.create() → FileHeap (or skip if no parser)
           ├── processFile()
           │     └── foreach commentNode
           │           └── foreach CommentPart
@@ -188,13 +188,14 @@ file path and stops the run (fail-fast). `register()` wraps registrar failures i
 
 **Class:** `Dto/HeapContext`
 
-Mutable run-scoped bag passed through `createFileHeap()`, `processFile()`, and `register()`:
+Mutable run-scoped bag passed through `FileHeapFactory.create()`, `processFile()`, and `register()`:
 
 | Property | Purpose |
 |---|---|
 | `statistic` | `ProcessStatistic` for the whole run |
 | `hashToKey` | Hash → issue key map for same-ticket gluing |
 | `glueSameTickets` | From `process.glueSameTickets` config |
+| `output` | Console output adapter for the run |
 
 Created once in `run()`; shared across all files in the run.
 

--- a/.cursor/docs/Architecture/ProcessingFlow.md
+++ b/.cursor/docs/Architecture/ProcessingFlow.md
@@ -15,7 +15,7 @@ HeapRunner.run()
             │       ├─► FileParserRegistry → ParsedFile (tokens + context map)
             │       └─► CommentNodesBuilder.build()  [optional sequential gluing]
             │
-            ├─► processFile()
+            ├─► FileProcessor.process()
             │       ├─► Comment/Extractor → CommentPart[]
             │       │       └─ skip if tag line has ticketKey
             │       ├─► TodoBuilder → Todo
@@ -118,7 +118,7 @@ Creates `ContextAwareTodo` (implements `Todo`):
 
 ## Step 7: Register Issue
 
-**Class:** `HeapRunner::register()`
+**Class:** `FileProcessor`
 
 Run-scoped state lives in `HeapContext` (`statistic`, `hashToKey`, `glueSameTickets`).
 
@@ -167,11 +167,11 @@ run()
   └── foreach finder → SplFileInfo
         try
           ├── FileHeapFactory.create() → FileHeap (or skip if no parser)
-          ├── processFile()
+          ├── FileProcessor.process()
           │     └── foreach commentNode
           │           └── foreach CommentPart
           │                 ├── TodoBuilder → Todo
-          │                 ├── register() + saveAfterRegistration()
+          │                 ├── FileProcessor.register() + saveAfterRegistration()
           │                 └── CommentRegistrationException propagates up
           └── logFileCompletion()
         catch Exception
@@ -181,14 +181,14 @@ run()
 
 Per-file processing is wrapped in a single `try/catch` in `run()`. Any `\Exception`
 (parse, glue gate, registration, todo building) triggers `writeError()` with the current
-file path and stops the run (fail-fast). `register()` wraps registrar failures in
+file path and stops the run (fail-fast). `FileProcessor` wraps registrar failures in
 `CommentRegistrationException` before they reach the outer catch.
 
 ## HeapContext
 
 **Class:** `Dto/HeapContext`
 
-Mutable run-scoped bag passed through `FileHeapFactory.create()`, `processFile()`, and `register()`:
+Mutable run-scoped bag passed through `FileHeapFactory.create()`, `FileProcessor.process()`, and registration:
 
 | Property | Purpose |
 |---|---|
@@ -205,7 +205,7 @@ Built once in `run()` via `HeapContextFactory`; shared across all files in the r
 |---|---|
 | No parser for file extension | `writeErr`, skip file (`continue`) |
 | Parse / glue gate / registration / build error | `writeError($exception, $file)` in `run()`, rethrow |
-| Registrar failure | Wrapped in `CommentRegistrationException` in `register()` |
+| Registrar failure | Wrapped in `CommentRegistrationException` in `FileProcessor` |
 
 ## Related Features
 

--- a/.cursor/docs/Architecture/ProcessingFlow.md
+++ b/.cursor/docs/Architecture/ProcessingFlow.md
@@ -163,7 +163,7 @@ Optional export via [Report](../Feature/Report.md).
 
 ```
 run()
-  ├── new HeapContext
+  ├── HeapContextFactory.create(config, output)
   └── foreach finder → SplFileInfo
         try
           ├── FileHeapFactory.create() → FileHeap (or skip if no parser)
@@ -197,7 +197,7 @@ Mutable run-scoped bag passed through `FileHeapFactory.create()`, `processFile()
 | `glueSameTickets` | From `process.glueSameTickets` config |
 | `output` | Console output adapter for the run |
 
-Created once in `run()`; shared across all files in the run.
+Built once in `run()` via `HeapContextFactory`; shared across all files in the run.
 
 ## Error Handling
 

--- a/.cursor/docs/Feature/IssueKeyInjection.md
+++ b/.cursor/docs/Feature/IssueKeyInjection.md
@@ -6,7 +6,7 @@ Controls how registrar-returned keys (`PROJ-123`, `#42`, `QUEUE-1`) are written 
 
 1. After `registrar->register($todo)`, `HeapRunner` calls `$todo->injectKey($key)`
 2. `CommentPart::injectKey()` modifies the first line of the comment at the configured position
-3. `FileHeap` save callback writes the updated tokens to disk via `Saver`
+3. `FileHeap::saveAfterRegistration()` writes the updated tokens to disk via `Saver`
 
 Works for PHP and YAML source files (any file type that uses `TokenInterface`).
 

--- a/.cursor/docs/Feature/IssueKeyInjection.md
+++ b/.cursor/docs/Feature/IssueKeyInjection.md
@@ -4,7 +4,7 @@ Controls how registrar-returned keys (`PROJ-123`, `#42`, `QUEUE-1`) are written 
 
 ## What It Does
 
-1. After `registrar->register($todo)`, `HeapRunner` calls `$todo->injectKey($key)`
+1. After `registrar->register($todo)`, `FileProcessor` calls `$todo->injectKey($key)`
 2. `CommentPart::injectKey()` modifies the first line of the comment at the configured position
 3. `FileHeap::saveAfterRegistration()` writes the updated tokens to disk via `Saver`
 

--- a/.cursor/docs/Feature/SameTicketGluing.md
+++ b/.cursor/docs/Feature/SameTicketGluing.md
@@ -5,7 +5,7 @@ Reuses an already-created issue key for identical TODOs within one run instead o
 ## What It Does
 
 1. `TodoBuilder` computes a hash (`crc32`) from tag, assignee, summary, and description
-2. Before calling the registrar, `HeapRunner` checks whether the same hash was already registered in this run
+2. Before calling the registrar, `HeapRunner` checks `HeapContext.hashToKey` for the same hash in this run
 3. If `process.glueSameTickets` is true and hash matches, skips API call, reuses stored key, increments glued counter
 4. Injects the reused key into all matching comments
 
@@ -36,6 +36,7 @@ Comparison scope: single CLI run only. Cross-run deduplication is not supported.
 | Class | Path |
 |---|---|
 | Gluing logic | `src/Service/HeapRunner.php` (`register()`) |
+| Run-scoped hash map | `src/Dto/HeapContext.php` (`hashToKey`) |
 | Hash calculation | `src/Service/TodoBuilder.php` (`calculateHash()`) |
 | Config | `src/Dto/GeneralConfig/ProcessConfig.php` |
 | Statistics | `src/Dto/ProcessStatistic.php` (`tickGluedTodo()`) |

--- a/.cursor/docs/Feature/SequentialCommentsGluing.md
+++ b/.cursor/docs/Feature/SequentialCommentsGluing.md
@@ -62,7 +62,7 @@ One `CommentNode`, two `CommentPart` objects, two registrations (unless same-tic
 
 | Class | Path |
 |---|---|
-| Grouping logic | `src/Dto/FileHeap.php` (`buildCommentNodes()`) |
+| Grouping logic | `src/Service/Comment/CommentNodesBuilder.php` |
 | Token stream | `src/Dto/Token/TokenStream.php`; `ParsedFile::getTokenStream()` |
 | Glue gates | `src/Service/Comment/SequentialCommentGlueGate/PhpSequentialCommentGlueGate.php`, `YamlSequentialCommentGlueGate.php` |
 | Gate registry | `src/Service/Comment/SequentialCommentGlueGateRegistry.php` |
@@ -70,6 +70,6 @@ One `CommentNode`, two `CommentPart` objects, two registrations (unless same-tic
 | Comment node | `src/Dto/Parsing/CommentNode.php` |
 | Config | `src/Dto/GeneralConfig/ProcessConfig.php` |
 
-Flow: `FileParserRegistry` → `ParsedFile` → `SequentialCommentGlueGateRegistry` + `FileHeap` → `Extractor`.
+Flow: `FileParserRegistry` → `ParsedFile` → `SequentialCommentGlueGateRegistry` + `CommentNodesBuilder` → `Extractor`.
 
 See also: [Source File Parsing](SourceFileParsing.md).

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,6 +23,7 @@ services:
       - '../src/Console/OutputAdapter.php'
       - '../src/Service/Comment/Extractor.php'
       - '../src/Service/File/Finder.php'
+      - '../src/Service/FileProcessor.php'
       - '../src/Service/HeapRunner.php'
       - '../src/Service/InlineConfig/JsonLikeLexer.php'
       - '../src/Service/Registrar/GitHub/'

--- a/src/Dto/FileHeap.php
+++ b/src/Dto/FileHeap.php
@@ -26,27 +26,21 @@ use Aeliot\TodoRegistrar\Service\File\Saver;
  */
 final class FileHeap
 {
-    private FileStatistic $fileStatistic;
-    private \Closure $fileUpdateCallback;
-
     /**
      * @var CommentNode[]|null
      */
     private ?array $commentNodes = null;
+
+    private FileStatistic $fileStatistic;
 
     public function __construct(
         private readonly ParsedFile $parsedFile,
         private readonly bool $glueSequentialComments,
         private readonly ?SequentialCommentGlueGateInterface $glueGate,
         private readonly ProcessStatistic $statistic,
-        Saver $saver,
+        private readonly Saver $saver,
     ) {
-        $file = $parsedFile->getFile();
-        $this->fileStatistic = new FileStatistic($file->getPathname(), $statistic);
-        $this->fileUpdateCallback = function () use ($file, $saver): void {
-            $this->fileStatistic->tickRegistration();
-            $saver->save($file, $this->parsedFile->getTokenStream());
-        };
+        $this->fileStatistic = new FileStatistic($parsedFile->getFile()->getPathname(), $statistic);
     }
 
     /**
@@ -57,14 +51,15 @@ final class FileHeap
         return $this->commentNodes ??= $this->buildCommentNodes();
     }
 
-    public function getFileUpdateCallback(): \Closure
-    {
-        return $this->fileUpdateCallback;
-    }
-
     public function getRegistrationCount(): int
     {
         return $this->fileStatistic->getRegistrationCount();
+    }
+
+    public function saveAfterRegistration(): void
+    {
+        $this->fileStatistic->tickRegistration();
+        $this->saver->save($this->parsedFile->getFile(), $this->parsedFile->getTokenStream());
     }
 
     /**

--- a/src/Dto/FileHeap.php
+++ b/src/Dto/FileHeap.php
@@ -14,10 +14,8 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Dto;
 
 use Aeliot\TodoRegistrar\Dto\Parsing\CommentNode;
-use Aeliot\TodoRegistrar\Dto\Parsing\MappedContext;
 use Aeliot\TodoRegistrar\Dto\Parsing\ParsedFile;
-use Aeliot\TodoRegistrar\Dto\Token\CommentTokensGroup;
-use Aeliot\TodoRegistrar\Dto\Token\TokenInterface;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
 use Aeliot\TodoRegistrar\Service\Comment\SequentialCommentGlueGateInterface;
 use Aeliot\TodoRegistrar\Service\File\Saver;
 
@@ -34,6 +32,7 @@ final class FileHeap
     private FileStatistic $fileStatistic;
 
     public function __construct(
+        private readonly CommentNodesBuilder $commentNodesBuilder,
         private readonly ParsedFile $parsedFile,
         private readonly bool $glueSequentialComments,
         private readonly ?SequentialCommentGlueGateInterface $glueGate,
@@ -48,7 +47,12 @@ final class FileHeap
      */
     public function getCommentNodes(): array
     {
-        return $this->commentNodes ??= $this->buildCommentNodes();
+        return $this->commentNodes ??= $this->commentNodesBuilder->build(
+            $this->parsedFile,
+            $this->glueSequentialComments,
+            $this->glueGate,
+            $this->statistic,
+        );
     }
 
     public function getRegistrationCount(): int
@@ -60,60 +64,5 @@ final class FileHeap
     {
         $this->fileStatistic->tickRegistration();
         $this->saver->save($this->parsedFile->getFile(), $this->parsedFile->getTokenStream());
-    }
-
-    /**
-     * @return CommentNode[]
-     */
-    private function buildCommentNodes(): array
-    {
-        $commentNodes = [];
-        $group = new CommentTokensGroup();
-        $stream = $this->parsedFile->getTokenStream();
-
-        while (!$stream->isEnd()) {
-            $token = $stream->current();
-            if ($token->isComment()) {
-                $this->statistic->tickCommentToken();
-            }
-
-            if ($this->glueSequentialComments && $this->glueGate?->canGlueCurrent($stream, !$group->isEmpty())) {
-                $group->addToken($token);
-                $stream->next();
-                continue;
-            }
-
-            if (!$token->isComment()) {
-                if (!$group->isEmpty()) {
-                    if ('' !== trim($token->getText())) {
-                        $commentNodes[] = $this->createCommentNode($group->grabTokens());
-                    } elseif (null !== $this->glueGate) {
-                        $commentNodes[] = $this->createCommentNode($group->grabTokens());
-                    }
-                }
-                $stream->next();
-                continue;
-            }
-
-            if (!$group->isEmpty()) {
-                $commentNodes[] = $this->createCommentNode($group->grabTokens());
-            }
-            $commentNodes[] = $this->createCommentNode([$token]);
-            $stream->next();
-        }
-
-        if (!$group->isEmpty()) {
-            $commentNodes[] = $this->createCommentNode($group->grabTokens());
-        }
-
-        return $commentNodes;
-    }
-
-    /**
-     * @param TokenInterface[] $tokens
-     */
-    private function createCommentNode(array $tokens): CommentNode
-    {
-        return new CommentNode($tokens, new MappedContext($tokens[0]->getLine(), $this->parsedFile->getContextMap()));
     }
 }

--- a/src/Dto/HeapContext.php
+++ b/src/Dto/HeapContext.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Dto;
+
+final class HeapContext
+{
+    public ProcessStatistic $statistic;
+
+    /**
+     * @var array<string,string>
+     */
+    public array $hashToKey;
+    public bool $glueSameTickets;
+}

--- a/src/Dto/HeapContext.php
+++ b/src/Dto/HeapContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Dto;
 
+use Aeliot\TodoRegistrar\Console\OutputAdapter;
+
 final class HeapContext
 {
     /**
@@ -27,6 +29,8 @@ final class HeapContext
      * @var array<string,string>
      */
     public array $hashToKey;
+
+    public OutputAdapter $output;
 
     public ProcessStatistic $statistic;
 }

--- a/src/Dto/HeapContext.php
+++ b/src/Dto/HeapContext.php
@@ -22,10 +22,11 @@ final class HeapContext
 
     public bool $glueSameTickets;
     public bool $glueSequentialComments;
-    public ProcessStatistic $statistic;
 
     /**
      * @var array<string,string>
      */
     public array $hashToKey;
+
+    public ProcessStatistic $statistic;
 }

--- a/src/Dto/HeapContext.php
+++ b/src/Dto/HeapContext.php
@@ -15,11 +15,17 @@ namespace Aeliot\TodoRegistrar\Dto;
 
 final class HeapContext
 {
+    /**
+     * @var array<string,string>
+     */
+    public array $extensionAliases;
+
+    public bool $glueSameTickets;
+    public bool $glueSequentialComments;
     public ProcessStatistic $statistic;
 
     /**
      * @var array<string,string>
      */
     public array $hashToKey;
-    public bool $glueSameTickets;
 }

--- a/src/Service/Comment/CommentNodesBuilder.php
+++ b/src/Service/Comment/CommentNodesBuilder.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Service\Comment;
+
+use Aeliot\TodoRegistrar\Dto\Parsing\CommentNode;
+use Aeliot\TodoRegistrar\Dto\Parsing\MappedContext;
+use Aeliot\TodoRegistrar\Dto\Parsing\ParsedFile;
+use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
+use Aeliot\TodoRegistrar\Dto\Token\CommentTokensGroup;
+use Aeliot\TodoRegistrar\Dto\Token\TokenInterface;
+
+/**
+ * @internal
+ */
+final readonly class CommentNodesBuilder
+{
+    /**
+     * @return CommentNode[]
+     */
+    public function build(
+        ParsedFile $parsedFile,
+        bool $glueSequentialComments,
+        ?SequentialCommentGlueGateInterface $glueGate,
+        ProcessStatistic $statistic,
+    ): array {
+        $commentNodes = [];
+        $group = new CommentTokensGroup();
+        $stream = $parsedFile->getTokenStream();
+
+        while (!$stream->isEnd()) {
+            $token = $stream->current();
+            if ($token->isComment()) {
+                $statistic->tickCommentToken();
+            }
+
+            if ($glueSequentialComments && $glueGate?->canGlueCurrent($stream, !$group->isEmpty())) {
+                $group->addToken($token);
+                $stream->next();
+                continue;
+            }
+
+            if (!$token->isComment()) {
+                if (!$group->isEmpty()) {
+                    if ('' !== trim($token->getText())) {
+                        $commentNodes[] = $this->createCommentNode($parsedFile, $group->grabTokens());
+                    } elseif (null !== $glueGate) {
+                        $commentNodes[] = $this->createCommentNode($parsedFile, $group->grabTokens());
+                    }
+                }
+                $stream->next();
+                continue;
+            }
+
+            if (!$group->isEmpty()) {
+                $commentNodes[] = $this->createCommentNode($parsedFile, $group->grabTokens());
+            }
+            $commentNodes[] = $this->createCommentNode($parsedFile, [$token]);
+            $stream->next();
+        }
+
+        if (!$group->isEmpty()) {
+            $commentNodes[] = $this->createCommentNode($parsedFile, $group->grabTokens());
+        }
+
+        return $commentNodes;
+    }
+
+    /**
+     * @param TokenInterface[] $tokens
+     */
+    private function createCommentNode(ParsedFile $parsedFile, array $tokens): CommentNode
+    {
+        return new CommentNode($tokens, new MappedContext($tokens[0]->getLine(), $parsedFile->getContextMap()));
+    }
+}

--- a/src/Service/FileHeapFactory.php
+++ b/src/Service/FileHeapFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Service;
+
+use Aeliot\TodoRegistrar\Console\OutputAdapter;
+use Aeliot\TodoRegistrar\Dto\FileHeap;
+use Aeliot\TodoRegistrar\Dto\HeapContext;
+use Aeliot\TodoRegistrar\Exception\FileReadException;
+use Aeliot\TodoRegistrar\Exception\LogicException;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
+use Aeliot\TodoRegistrar\Service\Comment\SequentialCommentGlueGateRegistry;
+use Aeliot\TodoRegistrar\Service\File\FileParserRegistry;
+use Aeliot\TodoRegistrar\Service\File\Saver;
+
+/**
+ * @internal
+ */
+final readonly class FileHeapFactory
+{
+    public function __construct(
+        private CommentNodesBuilder $commentNodesBuilder,
+        private FileParserRegistry $fileParserRegistry,
+        private SequentialCommentGlueGateRegistry $glueGateRegistry,
+        private Saver $saver,
+    ) {
+    }
+
+    /**
+     * @throws FileReadException
+     * @throws LogicException
+     */
+    public function create(\SplFileInfo $file, HeapContext $context): ?FileHeap
+    {
+        $extension = strtolower($file->getExtension());
+        $extensionAlias = $context->extensionAliases[$extension] ?? $extension;
+        $fileParser = $this->fileParserRegistry->findParser($extensionAlias);
+        if (!$fileParser) {
+            $context->output->writeErr("There is not configured parser for file: {$file->getPathname()}", OutputAdapter::VERBOSITY_NORMAL);
+
+            return null;
+        }
+
+        $context->output->writeln("Begin process file: {$file->getPathname()}", OutputAdapter::VERBOSITY_DEBUG);
+        $glueGate = null;
+        if ($context->glueSequentialComments) {
+            $glueGate = $this->glueGateRegistry->find($extensionAlias);
+            if (null === $glueGate) {
+                throw new LogicException(\sprintf('Sequential comment glue is enabled but no glue gate is configured for extension alias "%s" (file: %s)', $extensionAlias, $file->getPathname()));
+            }
+        }
+
+        $fileHeap = new FileHeap(
+            $this->commentNodesBuilder,
+            $fileParser->parse($file),
+            $context->glueSequentialComments,
+            $glueGate,
+            $context->statistic,
+            $this->saver,
+        );
+
+        if ($context->output->isDebug()) {
+            $context->output->writeln('Detected comment nodes: ' . \count($fileHeap->getCommentNodes()));
+        }
+
+        return $fileHeap;
+    }
+}

--- a/src/Service/FileProcessor.php
+++ b/src/Service/FileProcessor.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Service;
+
+use Aeliot\TodoRegistrar\Console\OutputAdapter;
+use Aeliot\TodoRegistrar\Dto\Comment\CommentPart;
+use Aeliot\TodoRegistrar\Dto\FileHeap;
+use Aeliot\TodoRegistrar\Dto\HeapContext;
+use Aeliot\TodoRegistrar\Dto\Registrar\Todo;
+use Aeliot\TodoRegistrar\Exception\CommentRegistrationException;
+use Aeliot\TodoRegistrar\Exception\NoLineException;
+use Aeliot\TodoRegistrar\Service\Comment\Extractor as CommentExtractor;
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface;
+
+/**
+ * @internal
+ */
+final readonly class FileProcessor
+{
+    public function __construct(
+        private CommentExtractor $commentExtractor,
+        private RegistrarInterface $registrar,
+        private TodoBuilder $todoBuilder,
+    ) {
+    }
+
+    /**
+     * @throws CommentRegistrationException
+     * @throws NoLineException
+     */
+    public function process(FileHeap $fileHeap, HeapContext $context): void
+    {
+        foreach ($fileHeap->getCommentNodes() as $commentNode) {
+            foreach ($this->commentExtractor->extract($commentNode) as $commentPart) {
+                if ($this->skipRegisteredTodo($commentPart, $context)) {
+                    continue;
+                }
+
+                $todo = $this->todoBuilder->create($commentPart);
+                $this->register($todo, $context);
+                $fileHeap->saveAfterRegistration();
+            }
+        }
+    }
+
+    /**
+     * @throws CommentRegistrationException
+     */
+    private function register(Todo $todo, HeapContext $context): void
+    {
+        try {
+            $hash = $todo->getHash();
+            if ($context->glueSameTickets && isset($context->hashToKey[$hash])) {
+                $key = $context->hashToKey[$hash];
+                $context->output->writeln("Injected existing key: {$context->hashToKey[$hash]}", OutputAdapter::VERBOSITY_VERBOSE);
+                $context->statistic->tickGluedTodo();
+            } else {
+                $context->hashToKey[$hash] = $key = $this->registrar->register($todo);
+                $context->output->writeln("Registered new key: $key", OutputAdapter::VERBOSITY_VERBOSE);
+            }
+            $todo->injectKey($key);
+        } catch (\Throwable $exception) {
+            throw new CommentRegistrationException($todo, $exception);
+        }
+    }
+
+    private function skipRegisteredTodo(CommentPart $commentPart, HeapContext $context): bool
+    {
+        $ticketKey = $commentPart->getTagMetadata()?->getTicketKey();
+        if (!$ticketKey) {
+            return false;
+        }
+
+        $context->statistic->tickIgnoredTodo();
+        $context->output->writeln("Skip TODO with Key: {$ticketKey}", OutputAdapter::VERBOSITY_DEBUG);
+
+        return true;
+    }
+}

--- a/src/Service/HeapContextFactory.php
+++ b/src/Service/HeapContextFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Service;
+
+use Aeliot\TodoRegistrar\Console\OutputAdapter;
+use Aeliot\TodoRegistrar\Dto\GeneralConfig\ProcessConfig;
+use Aeliot\TodoRegistrar\Dto\HeapContext;
+use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\ProcessConfigAwareInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\ProcessConfigInterface;
+
+/**
+ * @internal
+ */
+final readonly class HeapContextFactory
+{
+    public function create(GeneralConfigInterface $config, OutputAdapter $output): HeapContext
+    {
+        $context = new HeapContext();
+        $context->statistic = new ProcessStatistic();
+        $context->extensionAliases = $this->getExtensionAliases($config);
+        $context->hashToKey = [];
+        $context->glueSameTickets = $this->getGlueSameTickets($config);
+        $context->glueSequentialComments = $this->getGlueSequentialComments($config);
+        $context->output = $output;
+
+        return $context;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getExtensionAliases(GeneralConfigInterface $config): array
+    {
+        return array_map('strtolower', ($config instanceof ProcessConfigAwareInterface
+            ? $config->getProcessConfig()?->getExtensionAliases()
+            : null) ?? []);
+    }
+
+    private function getGlueSameTickets(GeneralConfigInterface $config): bool
+    {
+        $processConfig = $config instanceof ProcessConfigAwareInterface
+            ? $config->getProcessConfig()
+            : null;
+
+        $isGlueSameTicket = null;
+        if ($processConfig instanceof ProcessConfigInterface) {
+            $isGlueSameTicket = $processConfig->isGlueSameTicket();
+        }
+
+        return $isGlueSameTicket ?? ProcessConfig::DEFAULT_GLUE_SAME_TICKETS;
+    }
+
+    private function getGlueSequentialComments(GeneralConfigInterface $config): bool
+    {
+        return ($config instanceof ProcessConfigAwareInterface
+            ? $config->getProcessConfig()?->isGlueSequentialComments()
+            : null) ?? ProcessConfig::DEFAULT_GLUE_SEQUENTIAL_COMMENTS;
+    }
+}

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -61,8 +61,10 @@ final readonly class HeapRunner
     {
         $context = new HeapContext();
         $context->statistic = new ProcessStatistic();
+        $context->extensionAliases = $this->getExtensionAliases();
         $context->hashToKey = [];
         $context->glueSameTickets = $this->getGlueSameTickets();
+        $context->glueSequentialComments = $this->getGlueSequentialComments();
 
         foreach ($this->finder as $file) {
             try {
@@ -87,24 +89,13 @@ final readonly class HeapRunner
     }
 
     /**
-     * @return array<string, string>
-     */
-    private function getExtensionAliases(): array
-    {
-        return array_map('strtolower', ($this->config instanceof ProcessConfigAwareInterface
-            ? $this->config->getProcessConfig()?->getExtensionAliases()
-            : null) ?? []);
-    }
-
-    /**
      * @throws FileReadException
      * @throws LogicException
      */
     private function createFileHeap(\SplFileInfo $file, HeapContext $context): ?FileHeap
     {
-        $extensionAliases = $this->getExtensionAliases();
         $extension = strtolower($file->getExtension());
-        $extensionAlias = $extensionAliases[$extension] ?? $extension;
+        $extensionAlias = $context->extensionAliases[$extension] ?? $extension;
         $fileParser = $this->fileParserRegistry->findParser($extensionAlias);
         if (!$fileParser) {
             $this->output->writeErr("There is not configured parser for file: {$file->getPathname()}", OutputAdapter::VERBOSITY_NORMAL);
@@ -113,9 +104,8 @@ final readonly class HeapRunner
         }
 
         $this->output->writeln("Begin process file: {$file->getPathname()}", OutputAdapter::VERBOSITY_DEBUG);
-        $glueSequentialComments = $this->getGlueSequentialComments();
         $glueGate = null;
-        if ($glueSequentialComments) {
+        if ($context->glueSequentialComments) {
             $glueGate = $this->glueGateRegistry->find($extensionAlias);
             if (null === $glueGate) {
                 throw new LogicException(\sprintf('Sequential comment glue is enabled but no glue gate is configured for extension alias "%s" (file: %s)', $extensionAlias, $file->getPathname()));
@@ -124,7 +114,7 @@ final readonly class HeapRunner
 
         $fileHeap = new FileHeap(
             $fileParser->parse($file),
-            $glueSequentialComments,
+            $context->glueSequentialComments,
             $glueGate,
             $context->statistic,
             $this->saver,
@@ -135,6 +125,16 @@ final readonly class HeapRunner
         }
 
         return $fileHeap;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getExtensionAliases(): array
+    {
+        return array_map('strtolower', ($this->config instanceof ProcessConfigAwareInterface
+            ? $this->config->getProcessConfig()?->getExtensionAliases()
+            : null) ?? []);
     }
 
     private function getGlueSameTickets(): bool

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -23,11 +23,7 @@ use Aeliot\TodoRegistrar\Exception\CommentRegistrationException;
 use Aeliot\TodoRegistrar\Exception\FileReadException;
 use Aeliot\TodoRegistrar\Exception\LogicException;
 use Aeliot\TodoRegistrar\Exception\NoLineException;
-use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
 use Aeliot\TodoRegistrar\Service\Comment\Extractor as CommentExtractor;
-use Aeliot\TodoRegistrar\Service\Comment\SequentialCommentGlueGateRegistry;
-use Aeliot\TodoRegistrar\Service\File\FileParserRegistry;
-use Aeliot\TodoRegistrar\Service\File\Saver;
 use Aeliot\TodoRegistrarContracts\FinderInterface;
 use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
 use Aeliot\TodoRegistrarContracts\GeneralConfig\ProcessConfigAwareInterface;
@@ -41,13 +37,10 @@ final readonly class HeapRunner
 {
     public function __construct(
         private CommentExtractor $commentExtractor,
-        private CommentNodesBuilder $commentNodesBuilder,
+        private FileHeapFactory $fileHeapFactory,
         private FinderInterface $finder,
-        private FileParserRegistry $fileParserRegistry,
-        private SequentialCommentGlueGateRegistry $glueGateRegistry,
         private OutputAdapter $output,
         private RegistrarInterface $registrar,
-        private Saver $saver,
         private TodoBuilder $todoBuilder,
         private GeneralConfigInterface $config,
     ) {
@@ -67,10 +60,11 @@ final readonly class HeapRunner
         $context->hashToKey = [];
         $context->glueSameTickets = $this->getGlueSameTickets();
         $context->glueSequentialComments = $this->getGlueSequentialComments();
+        $context->output = $this->output;
 
         foreach ($this->finder as $file) {
             try {
-                $fileHeap = $this->createFileHeap($file, $context);
+                $fileHeap = $this->fileHeapFactory->create($file, $context);
                 if (null === $fileHeap) {
                     continue;
                 }
@@ -88,46 +82,6 @@ final readonly class HeapRunner
         }
 
         return $context->statistic;
-    }
-
-    /**
-     * @throws FileReadException
-     * @throws LogicException
-     */
-    private function createFileHeap(\SplFileInfo $file, HeapContext $context): ?FileHeap
-    {
-        $extension = strtolower($file->getExtension());
-        $extensionAlias = $context->extensionAliases[$extension] ?? $extension;
-        $fileParser = $this->fileParserRegistry->findParser($extensionAlias);
-        if (!$fileParser) {
-            $this->output->writeErr("There is not configured parser for file: {$file->getPathname()}", OutputAdapter::VERBOSITY_NORMAL);
-
-            return null;
-        }
-
-        $this->output->writeln("Begin process file: {$file->getPathname()}", OutputAdapter::VERBOSITY_DEBUG);
-        $glueGate = null;
-        if ($context->glueSequentialComments) {
-            $glueGate = $this->glueGateRegistry->find($extensionAlias);
-            if (null === $glueGate) {
-                throw new LogicException(\sprintf('Sequential comment glue is enabled but no glue gate is configured for extension alias "%s" (file: %s)', $extensionAlias, $file->getPathname()));
-            }
-        }
-
-        $fileHeap = new FileHeap(
-            $this->commentNodesBuilder,
-            $fileParser->parse($file),
-            $context->glueSequentialComments,
-            $glueGate,
-            $context->statistic,
-            $this->saver,
-        );
-
-        if ($this->output->isDebug()) {
-            $this->output->writeln('Detected comment nodes: ' . \count($fileHeap->getCommentNodes()));
-        }
-
-        return $fileHeap;
     }
 
     /**

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Aeliot\TodoRegistrar\Service;
 
 use Aeliot\TodoRegistrar\Console\OutputAdapter;
-use Aeliot\TodoRegistrar\Dto\Comment\CommentPart;
 use Aeliot\TodoRegistrar\Dto\FileHeap;
 use Aeliot\TodoRegistrar\Dto\GeneralConfig\ProcessConfig;
+use Aeliot\TodoRegistrar\Dto\HeapContext;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
 use Aeliot\TodoRegistrar\Dto\Registrar\Todo;
 use Aeliot\TodoRegistrar\Exception\CommentRegistrationException;
@@ -59,44 +59,31 @@ final readonly class HeapRunner
      */
     public function run(): ProcessStatistic
     {
-        $statistic = new ProcessStatistic();
-        $hashToKey = [];
-        $glueSameTickets = $this->getGlueSameTickets();
+        $context = new HeapContext();
+        $context->statistic = new ProcessStatistic();
+        $context->hashToKey = [];
+        $context->glueSameTickets = $this->getGlueSameTickets();
 
-        foreach ($this->getTodos($statistic) as [$todo, $fileUpdateCallback]) {
-            $this->register($todo, $glueSameTickets, $hashToKey, $statistic);
-            $fileUpdateCallback();
-        }
-
-        return $statistic;
-    }
-
-    /**
-     * @return \Generator<array{0: CommentPart, 1: callable}>
-     *
-     * @throws LogicException
-     */
-    private function getCommentParts(ProcessStatistic $statistic): \Generator
-    {
-        foreach ($this->getFileHeaps($statistic) as $fileHeap) {
-            foreach ($fileHeap->getCommentNodes() as $commentNode) {
-                $todos = $this->commentExtractor->extract($commentNode);
-
-                foreach ($todos as $commentPart) {
-                    $ticketKey = $commentPart->getTagMetadata()?->getTicketKey();
-                    if ($ticketKey) {
-                        $statistic->tickIgnoredTodo();
-                        $this->output->writeln("Skip TODO with Key: {$ticketKey}", OutputAdapter::VERBOSITY_DEBUG);
-                        continue;
-                    }
-
-                    yield [
-                        $commentPart,
-                        $fileHeap->getFileUpdateCallback(),
-                    ];
+        foreach ($this->finder as $file) {
+            try {
+                $fileHeap = $this->createFileHeap($file, $context);
+                if (null === $fileHeap) {
+                    continue;
                 }
+
+                $this->processFile($fileHeap, $context);
+                $this->logFileCompletion($file, $fileHeap);
+            } catch (\Exception $exception) {
+                /*
+                 * TODO: #196 refactor handling of exceptions
+                 *       Consider points when continuing is possible and when is not
+                 */
+                $this->writeError($exception, $file);
+                throw $exception;
             }
         }
+
+        return $context->statistic;
     }
 
     /**
@@ -110,68 +97,44 @@ final readonly class HeapRunner
     }
 
     /**
-     * @return \Generator<FileHeap>
-     *
      * @throws FileReadException
      * @throws LogicException
      */
-    private function getFileHeaps(ProcessStatistic $statistic): \Generator
+    private function createFileHeap(\SplFileInfo $file, HeapContext $context): ?FileHeap
     {
         $extensionAliases = $this->getExtensionAliases();
+        $extension = strtolower($file->getExtension());
+        $extensionAlias = $extensionAliases[$extension] ?? $extension;
+        $fileParser = $this->fileParserRegistry->findParser($extensionAlias);
+        if (!$fileParser) {
+            $this->output->writeErr("There is not configured parser for file: {$file->getPathname()}", OutputAdapter::VERBOSITY_NORMAL);
+
+            return null;
+        }
+
+        $this->output->writeln("Begin process file: {$file->getPathname()}", OutputAdapter::VERBOSITY_DEBUG);
         $glueSequentialComments = $this->getGlueSequentialComments();
-
-        foreach ($this->finder as $file) {
-            $extension = strtolower($file->getExtension());
-            $extensionAlias = $extensionAliases[$extension] ?? $extension;
-            $fileParser = $this->fileParserRegistry->findParser($extensionAlias);
-            if (!$fileParser) {
-                $this->output->writeErr("There is not configured parser for file: {$file->getPathname()}", OutputAdapter::VERBOSITY_NORMAL);
-                continue;
-            }
-
-            $this->output->writeln("Begin process file: {$file->getPathname()}", OutputAdapter::VERBOSITY_DEBUG);
-            try {
-                $glueGate = null;
-                if ($glueSequentialComments) {
-                    $glueGate = $this->glueGateRegistry->find($extensionAlias);
-                    if (null === $glueGate) {
-                        throw new LogicException(\sprintf('Sequential comment glue is enabled but no glue gate is configured for extension alias "%s" (file: %s)', $extensionAlias, $file->getPathname()));
-                    }
-                }
-
-                $fileHeap = new FileHeap(
-                    $fileParser->parse($file),
-                    $glueSequentialComments,
-                    $glueGate,
-                    $statistic,
-                    $this->saver,
-                );
-
-                $countCommentNodes = \count($fileHeap->getCommentNodes());
-                if ($this->output->isDebug()) {
-                    $this->output->writeln("Detected comment nodes: {$countCommentNodes}");
-                }
-
-                yield $fileHeap;
-
-                if (
-                    $this->output->isDebug()
-                    || ($this->output->isVeryVerbose() && $countCommentNodes)
-                    || ($this->output->isVerbose() && $fileHeap->getRegistrationCount())
-                ) {
-                    $this->output->writeln(
-                        "Registered {$fileHeap->getRegistrationCount()} for file: {$file->getPathname()}"
-                    );
-                }
-            } catch (\Throwable $exception) {
-                /*
-                 * TODO: #196 refactor handling of exceptions
-                 *       Consider points when continuing is possible and when is not
-                 */
-                $this->writeError($exception, $file);
-                throw $exception;
+        $glueGate = null;
+        if ($glueSequentialComments) {
+            $glueGate = $this->glueGateRegistry->find($extensionAlias);
+            if (null === $glueGate) {
+                throw new LogicException(\sprintf('Sequential comment glue is enabled but no glue gate is configured for extension alias "%s" (file: %s)', $extensionAlias, $file->getPathname()));
             }
         }
+
+        $fileHeap = new FileHeap(
+            $fileParser->parse($file),
+            $glueSequentialComments,
+            $glueGate,
+            $context->statistic,
+            $this->saver,
+        );
+
+        if ($this->output->isDebug()) {
+            $this->output->writeln('Detected comment nodes: ' . \count($fileHeap->getCommentNodes()));
+        }
+
+        return $fileHeap;
     }
 
     private function getGlueSameTickets(): bool
@@ -195,34 +158,56 @@ final readonly class HeapRunner
             : null) ?? ProcessConfig::DEFAULT_GLUE_SEQUENTIAL_COMMENTS;
     }
 
-    /**
-     * @return \Generator<array{0: Todo, 1: callable}>
-     *
-     * @throws LogicException
-     * @throws NoLineException
-     */
-    private function getTodos(ProcessStatistic $statistic): \Generator
+    private function logFileCompletion(\SplFileInfo $file, FileHeap $fileHeap): void
     {
-        foreach ($this->getCommentParts($statistic) as [$commentPart, $fileUpdateCallback]) {
-            yield [$this->todoBuilder->create($commentPart), $fileUpdateCallback];
+        if (
+            $this->output->isDebug()
+            || ($this->output->isVeryVerbose() && $fileHeap->getCommentNodes())
+            || ($this->output->isVerbose() && $fileHeap->getRegistrationCount())
+        ) {
+            $this->output->writeln(
+                "Registered {$fileHeap->getRegistrationCount()} for file: {$file->getPathname()}"
+            );
         }
     }
 
     /**
-     * @param array<string,string> $hashToKey
-     *
+     * @throws CommentRegistrationException
+     * @throws FileReadException
+     * @throws LogicException
+     * @throws NoLineException
+     */
+    private function processFile(FileHeap $fileHeap, HeapContext $context): void
+    {
+        foreach ($fileHeap->getCommentNodes() as $commentNode) {
+            foreach ($this->commentExtractor->extract($commentNode) as $commentPart) {
+                $ticketKey = $commentPart->getTagMetadata()?->getTicketKey();
+                if ($ticketKey) {
+                    $context->statistic->tickIgnoredTodo();
+                    $this->output->writeln("Skip TODO with Key: {$ticketKey}", OutputAdapter::VERBOSITY_DEBUG);
+                    continue;
+                }
+
+                $todo = $this->todoBuilder->create($commentPart);
+                $this->register($todo, $context);
+                $fileHeap->getFileUpdateCallback()();
+            }
+        }
+    }
+
+    /**
      * @throws CommentRegistrationException
      */
-    private function register(Todo $todo, bool $glueSameTickets, array &$hashToKey, ProcessStatistic $statistic): void
+    private function register(Todo $todo, HeapContext $context): void
     {
         try {
             $hash = $todo->getHash();
-            if ($glueSameTickets && isset($hashToKey[$hash])) {
-                $key = $hashToKey[$hash];
-                $this->output->writeln("Injected existing key: {$hashToKey[$hash]}", OutputAdapter::VERBOSITY_VERBOSE);
-                $statistic->tickGluedTodo();
+            if ($context->glueSameTickets && isset($context->hashToKey[$hash])) {
+                $key = $context->hashToKey[$hash];
+                $this->output->writeln("Injected existing key: {$context->hashToKey[$hash]}", OutputAdapter::VERBOSITY_VERBOSE);
+                $context->statistic->tickGluedTodo();
             } else {
-                $hashToKey[$hash] = $key = $this->registrar->register($todo);
+                $context->hashToKey[$hash] = $key = $this->registrar->register($todo);
                 $this->output->writeln("Registered new key: $key", OutputAdapter::VERBOSITY_VERBOSE);
             }
             $todo->injectKey($key);

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -23,7 +23,6 @@ use Aeliot\TodoRegistrar\Exception\FileReadException;
 use Aeliot\TodoRegistrar\Exception\LogicException;
 use Aeliot\TodoRegistrar\Exception\NoLineException;
 use Aeliot\TodoRegistrar\Service\Comment\Extractor as CommentExtractor;
-use Aeliot\TodoRegistrarContracts\FinderInterface;
 use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
 use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface;
 
@@ -36,7 +35,6 @@ final readonly class HeapRunner
         private CommentExtractor $commentExtractor,
         private GeneralConfigInterface $config,
         private FileHeapFactory $fileHeapFactory,
-        private FinderInterface $finder,
         private HeapContextFactory $heapContextFactory,
         private OutputAdapter $output,
         private RegistrarInterface $registrar,
@@ -54,7 +52,7 @@ final readonly class HeapRunner
     {
         $context = $this->heapContextFactory->create($this->config, $this->output);
 
-        foreach ($this->finder as $file) {
+        foreach ($this->config->getFinder() as $file) {
             try {
                 $fileHeap = $this->fileHeapFactory->create($file, $context);
                 if (null === $fileHeap) {

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -190,7 +190,7 @@ final readonly class HeapRunner
 
                 $todo = $this->todoBuilder->create($commentPart);
                 $this->register($todo, $context);
-                $fileHeap->getFileUpdateCallback()();
+                $fileHeap->saveAfterRegistration();
             }
         }
     }

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -15,7 +15,6 @@ namespace Aeliot\TodoRegistrar\Service;
 
 use Aeliot\TodoRegistrar\Console\OutputAdapter;
 use Aeliot\TodoRegistrar\Dto\FileHeap;
-use Aeliot\TodoRegistrar\Dto\GeneralConfig\ProcessConfig;
 use Aeliot\TodoRegistrar\Dto\HeapContext;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
 use Aeliot\TodoRegistrar\Dto\Registrar\Todo;
@@ -26,8 +25,6 @@ use Aeliot\TodoRegistrar\Exception\NoLineException;
 use Aeliot\TodoRegistrar\Service\Comment\Extractor as CommentExtractor;
 use Aeliot\TodoRegistrarContracts\FinderInterface;
 use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
-use Aeliot\TodoRegistrarContracts\GeneralConfig\ProcessConfigAwareInterface;
-use Aeliot\TodoRegistrarContracts\GeneralConfig\ProcessConfigInterface;
 use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface;
 
 /**
@@ -37,12 +34,13 @@ final readonly class HeapRunner
 {
     public function __construct(
         private CommentExtractor $commentExtractor,
+        private GeneralConfigInterface $config,
         private FileHeapFactory $fileHeapFactory,
         private FinderInterface $finder,
+        private HeapContextFactory $heapContextFactory,
         private OutputAdapter $output,
         private RegistrarInterface $registrar,
         private TodoBuilder $todoBuilder,
-        private GeneralConfigInterface $config,
     ) {
     }
 
@@ -54,13 +52,7 @@ final readonly class HeapRunner
      */
     public function run(): ProcessStatistic
     {
-        $context = new HeapContext();
-        $context->statistic = new ProcessStatistic();
-        $context->extensionAliases = $this->getExtensionAliases();
-        $context->hashToKey = [];
-        $context->glueSameTickets = $this->getGlueSameTickets();
-        $context->glueSequentialComments = $this->getGlueSequentialComments();
-        $context->output = $this->output;
+        $context = $this->heapContextFactory->create($this->config, $this->output);
 
         foreach ($this->finder as $file) {
             try {
@@ -82,37 +74,6 @@ final readonly class HeapRunner
         }
 
         return $context->statistic;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function getExtensionAliases(): array
-    {
-        return array_map('strtolower', ($this->config instanceof ProcessConfigAwareInterface
-            ? $this->config->getProcessConfig()?->getExtensionAliases()
-            : null) ?? []);
-    }
-
-    private function getGlueSameTickets(): bool
-    {
-        $processConfig = $this->config instanceof ProcessConfigAwareInterface
-            ? $this->config->getProcessConfig()
-            : null;
-
-        $isGlueSameTicket = null;
-        if ($processConfig instanceof ProcessConfigInterface) {
-            $isGlueSameTicket = $processConfig->isGlueSameTicket();
-        }
-
-        return $isGlueSameTicket ?? ProcessConfig::DEFAULT_GLUE_SAME_TICKETS;
-    }
-
-    private function getGlueSequentialComments(): bool
-    {
-        return ($this->config instanceof ProcessConfigAwareInterface
-            ? $this->config->getProcessConfig()?->isGlueSequentialComments()
-            : null) ?? ProcessConfig::DEFAULT_GLUE_SEQUENTIAL_COMMENTS;
     }
 
     private function logFileCompletion(\SplFileInfo $file, FileHeap $fileHeap): void

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -23,6 +23,7 @@ use Aeliot\TodoRegistrar\Exception\CommentRegistrationException;
 use Aeliot\TodoRegistrar\Exception\FileReadException;
 use Aeliot\TodoRegistrar\Exception\LogicException;
 use Aeliot\TodoRegistrar\Exception\NoLineException;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
 use Aeliot\TodoRegistrar\Service\Comment\Extractor as CommentExtractor;
 use Aeliot\TodoRegistrar\Service\Comment\SequentialCommentGlueGateRegistry;
 use Aeliot\TodoRegistrar\Service\File\FileParserRegistry;
@@ -40,6 +41,7 @@ final readonly class HeapRunner
 {
     public function __construct(
         private CommentExtractor $commentExtractor,
+        private CommentNodesBuilder $commentNodesBuilder,
         private FinderInterface $finder,
         private FileParserRegistry $fileParserRegistry,
         private SequentialCommentGlueGateRegistry $glueGateRegistry,
@@ -113,6 +115,7 @@ final readonly class HeapRunner
         }
 
         $fileHeap = new FileHeap(
+            $this->commentNodesBuilder,
             $fileParser->parse($file),
             $context->glueSequentialComments,
             $glueGate,

--- a/src/Service/HeapRunner.php
+++ b/src/Service/HeapRunner.php
@@ -15,16 +15,12 @@ namespace Aeliot\TodoRegistrar\Service;
 
 use Aeliot\TodoRegistrar\Console\OutputAdapter;
 use Aeliot\TodoRegistrar\Dto\FileHeap;
-use Aeliot\TodoRegistrar\Dto\HeapContext;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
-use Aeliot\TodoRegistrar\Dto\Registrar\Todo;
 use Aeliot\TodoRegistrar\Exception\CommentRegistrationException;
 use Aeliot\TodoRegistrar\Exception\FileReadException;
 use Aeliot\TodoRegistrar\Exception\LogicException;
 use Aeliot\TodoRegistrar\Exception\NoLineException;
-use Aeliot\TodoRegistrar\Service\Comment\Extractor as CommentExtractor;
 use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
-use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface;
 
 /**
  * @internal
@@ -32,13 +28,11 @@ use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface;
 final readonly class HeapRunner
 {
     public function __construct(
-        private CommentExtractor $commentExtractor,
         private GeneralConfigInterface $config,
         private FileHeapFactory $fileHeapFactory,
+        private FileProcessor $fileProcessor,
         private HeapContextFactory $heapContextFactory,
         private OutputAdapter $output,
-        private RegistrarInterface $registrar,
-        private TodoBuilder $todoBuilder,
     ) {
     }
 
@@ -59,7 +53,7 @@ final readonly class HeapRunner
                     continue;
                 }
 
-                $this->processFile($fileHeap, $context);
+                $this->fileProcessor->process($fileHeap, $context);
                 $this->logFileCompletion($file, $fileHeap);
             } catch (\Exception $exception) {
                 /*
@@ -84,51 +78,6 @@ final readonly class HeapRunner
             $this->output->writeln(
                 "Registered {$fileHeap->getRegistrationCount()} for file: {$file->getPathname()}"
             );
-        }
-    }
-
-    /**
-     * @throws CommentRegistrationException
-     * @throws FileReadException
-     * @throws LogicException
-     * @throws NoLineException
-     */
-    private function processFile(FileHeap $fileHeap, HeapContext $context): void
-    {
-        foreach ($fileHeap->getCommentNodes() as $commentNode) {
-            foreach ($this->commentExtractor->extract($commentNode) as $commentPart) {
-                $ticketKey = $commentPart->getTagMetadata()?->getTicketKey();
-                if ($ticketKey) {
-                    $context->statistic->tickIgnoredTodo();
-                    $this->output->writeln("Skip TODO with Key: {$ticketKey}", OutputAdapter::VERBOSITY_DEBUG);
-                    continue;
-                }
-
-                $todo = $this->todoBuilder->create($commentPart);
-                $this->register($todo, $context);
-                $fileHeap->saveAfterRegistration();
-            }
-        }
-    }
-
-    /**
-     * @throws CommentRegistrationException
-     */
-    private function register(Todo $todo, HeapContext $context): void
-    {
-        try {
-            $hash = $todo->getHash();
-            if ($context->glueSameTickets && isset($context->hashToKey[$hash])) {
-                $key = $context->hashToKey[$hash];
-                $this->output->writeln("Injected existing key: {$context->hashToKey[$hash]}", OutputAdapter::VERBOSITY_VERBOSE);
-                $context->statistic->tickGluedTodo();
-            } else {
-                $context->hashToKey[$hash] = $key = $this->registrar->register($todo);
-                $this->output->writeln("Registered new key: $key", OutputAdapter::VERBOSITY_VERBOSE);
-            }
-            $todo->injectKey($key);
-        } catch (\Throwable $exception) {
-            throw new CommentRegistrationException($todo, $exception);
         }
     }
 

--- a/src/Service/HeapRunnerFactory.php
+++ b/src/Service/HeapRunnerFactory.php
@@ -54,7 +54,6 @@ final readonly class HeapRunnerFactory
             $commentExtractor,
             $config,
             $this->fileHeapFactory,
-            $config->getFinder(),
             $this->heapContextFactory,
             $output,
             $registrar,

--- a/src/Service/HeapRunnerFactory.php
+++ b/src/Service/HeapRunnerFactory.php
@@ -49,15 +49,14 @@ final readonly class HeapRunnerFactory
         $commentExtractor = $this->commentExtractorFactory->create($config);
         $registrar = $this->registrarProvider->getRegistrar($config);
         $todoBuilder = $this->todoBuilderFactory->create($config, $output);
+        $fileProcessor = new FileProcessor($commentExtractor, $registrar, $todoBuilder);
 
         return new HeapRunner(
-            $commentExtractor,
             $config,
             $this->fileHeapFactory,
+            $fileProcessor,
             $this->heapContextFactory,
             $output,
-            $registrar,
-            $todoBuilder,
         );
     }
 }

--- a/src/Service/HeapRunnerFactory.php
+++ b/src/Service/HeapRunnerFactory.php
@@ -30,6 +30,7 @@ final readonly class HeapRunnerFactory
         private CommentExtractorFactory $commentExtractorFactory,
         private ConfigProvider $configProvider,
         private FileHeapFactory $fileHeapFactory,
+        private HeapContextFactory $heapContextFactory,
         private RegistrarProvider $registrarProvider,
         private TodoBuilderFactory $todoBuilderFactory,
     ) {
@@ -51,12 +52,13 @@ final readonly class HeapRunnerFactory
 
         return new HeapRunner(
             $commentExtractor,
+            $config,
             $this->fileHeapFactory,
             $config->getFinder(),
+            $this->heapContextFactory,
             $output,
             $registrar,
             $todoBuilder,
-            $config,
         );
     }
 }

--- a/src/Service/HeapRunnerFactory.php
+++ b/src/Service/HeapRunnerFactory.php
@@ -19,11 +19,7 @@ use Aeliot\TodoRegistrar\Exception\InvalidConfigException;
 use Aeliot\TodoRegistrar\Exception\LogicException;
 use Aeliot\TodoRegistrar\Exception\NotSupportedConfigException;
 use Aeliot\TodoRegistrar\Exception\UnavailableConfigException;
-use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
-use Aeliot\TodoRegistrar\Service\Comment\SequentialCommentGlueGateRegistry;
 use Aeliot\TodoRegistrar\Service\Config\ConfigProvider;
-use Aeliot\TodoRegistrar\Service\File\FileParserRegistry;
-use Aeliot\TodoRegistrar\Service\File\Saver;
 
 /**
  * @internal
@@ -32,12 +28,9 @@ final readonly class HeapRunnerFactory
 {
     public function __construct(
         private CommentExtractorFactory $commentExtractorFactory,
-        private CommentNodesBuilder $commentNodesBuilder,
         private ConfigProvider $configProvider,
-        private FileParserRegistry $fileParserRegistry,
-        private SequentialCommentGlueGateRegistry $glueGateRegistry,
+        private FileHeapFactory $fileHeapFactory,
         private RegistrarProvider $registrarProvider,
-        private Saver $saver,
         private TodoBuilderFactory $todoBuilderFactory,
     ) {
     }
@@ -58,13 +51,10 @@ final readonly class HeapRunnerFactory
 
         return new HeapRunner(
             $commentExtractor,
-            $this->commentNodesBuilder,
+            $this->fileHeapFactory,
             $config->getFinder(),
-            $this->fileParserRegistry,
-            $this->glueGateRegistry,
             $output,
             $registrar,
-            $this->saver,
             $todoBuilder,
             $config,
         );

--- a/src/Service/HeapRunnerFactory.php
+++ b/src/Service/HeapRunnerFactory.php
@@ -19,6 +19,7 @@ use Aeliot\TodoRegistrar\Exception\InvalidConfigException;
 use Aeliot\TodoRegistrar\Exception\LogicException;
 use Aeliot\TodoRegistrar\Exception\NotSupportedConfigException;
 use Aeliot\TodoRegistrar\Exception\UnavailableConfigException;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
 use Aeliot\TodoRegistrar\Service\Comment\SequentialCommentGlueGateRegistry;
 use Aeliot\TodoRegistrar\Service\Config\ConfigProvider;
 use Aeliot\TodoRegistrar\Service\File\FileParserRegistry;
@@ -31,6 +32,7 @@ final readonly class HeapRunnerFactory
 {
     public function __construct(
         private CommentExtractorFactory $commentExtractorFactory,
+        private CommentNodesBuilder $commentNodesBuilder,
         private ConfigProvider $configProvider,
         private FileParserRegistry $fileParserRegistry,
         private SequentialCommentGlueGateRegistry $glueGateRegistry,
@@ -56,6 +58,7 @@ final readonly class HeapRunnerFactory
 
         return new HeapRunner(
             $commentExtractor,
+            $this->commentNodesBuilder,
             $config->getFinder(),
             $this->fileParserRegistry,
             $this->glueGateRegistry,

--- a/tests/Unit/Dto/Comment/CommentPartStartLineTest.php
+++ b/tests/Unit/Dto/Comment/CommentPartStartLineTest.php
@@ -18,6 +18,7 @@ use Aeliot\TodoRegistrar\Dto\FileHeap;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
 use Aeliot\TodoRegistrar\Service\Comment\Cleaner\PhpCommentCleaner;
 use Aeliot\TodoRegistrar\Service\Comment\CommentCleanerRegistry;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
 use Aeliot\TodoRegistrar\Service\Comment\Extractor;
 use Aeliot\TodoRegistrar\Service\Comment\SequentialCommentGlueGate\PhpSequentialCommentGlueGate;
 use Aeliot\TodoRegistrar\Service\File\Parser\PhpFileParser;
@@ -76,7 +77,7 @@ final class CommentPartStartLineTest extends TestCase
         $statistic = new ProcessStatistic();
         $saver = $this->createMock(Saver::class);
         $glueGate = $glueSequentialComments ? new PhpSequentialCommentGlueGate() : null;
-        $fileHeap = new FileHeap($parsedFile, $glueSequentialComments, $glueGate, $statistic, $saver);
+        $fileHeap = new FileHeap(new CommentNodesBuilder(), $parsedFile, $glueSequentialComments, $glueGate, $statistic, $saver);
 
         $extractor = new Extractor(
             new TagDetector(['todo', 'fixme'], [':', '-']),

--- a/tests/Unit/Dto/FileHeapTest.php
+++ b/tests/Unit/Dto/FileHeapTest.php
@@ -17,6 +17,7 @@ use Aeliot\TodoRegistrar\Dto\FileHeap;
 use Aeliot\TodoRegistrar\Dto\Parsing\CommentNode;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
 use Aeliot\TodoRegistrar\Dto\Token\TokenInterface;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
 use Aeliot\TodoRegistrar\Service\Comment\SequentialCommentGlueGate\PhpSequentialCommentGlueGate;
 use Aeliot\TodoRegistrar\Service\File\Parser\PhpFileParser;
 use Aeliot\TodoRegistrar\Service\File\Saver;
@@ -126,7 +127,7 @@ final class FileHeapTest extends TestCase
         $statistic = new ProcessStatistic();
         $saver = $this->createMock(Saver::class);
         $glueGate = $glueSequentialComments ? new PhpSequentialCommentGlueGate() : null;
-        $fileHeap = new FileHeap($parsedFile, $glueSequentialComments, $glueGate, $statistic, $saver);
+        $fileHeap = new FileHeap(new CommentNodesBuilder(), $parsedFile, $glueSequentialComments, $glueGate, $statistic, $saver);
 
         return $fileHeap->getCommentNodes();
     }

--- a/tests/Unit/Dto/FileHeapYamlGluingTest.php
+++ b/tests/Unit/Dto/FileHeapYamlGluingTest.php
@@ -17,6 +17,7 @@ use Aeliot\TodoRegistrar\Dto\FileHeap;
 use Aeliot\TodoRegistrar\Dto\Parsing\CommentNode;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
 use Aeliot\TodoRegistrar\Dto\Token\TokenInterface;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
 use Aeliot\TodoRegistrar\Service\Comment\SequentialCommentGlueGate\YamlSequentialCommentGlueGate;
 use Aeliot\TodoRegistrar\Service\File\Parser\YamlFileParser;
 use Aeliot\TodoRegistrar\Service\File\Saver;
@@ -251,7 +252,7 @@ final class FileHeapYamlGluingTest extends TestCase
         $statistic = new ProcessStatistic();
         $saver = $this->createMock(Saver::class);
         $glueGate = $glueSequentialComments ? new YamlSequentialCommentGlueGate() : null;
-        $fileHeap = new FileHeap($parsedFile, $glueSequentialComments, $glueGate, $statistic, $saver);
+        $fileHeap = new FileHeap(new CommentNodesBuilder(), $parsedFile, $glueSequentialComments, $glueGate, $statistic, $saver);
 
         return $fileHeap->getCommentNodes();
     }

--- a/tests/Unit/Service/File/FileParserContextTest.php
+++ b/tests/Unit/Service/File/FileParserContextTest.php
@@ -18,6 +18,7 @@ use Aeliot\TodoRegistrar\Dto\Parsing\CommentNode;
 use Aeliot\TodoRegistrar\Dto\Parsing\ParsedFile;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
 use Aeliot\TodoRegistrar\Exception\BadMethodCallException;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
 use Aeliot\TodoRegistrar\Service\File\Parser\PhpFileParser;
 use Aeliot\TodoRegistrar\Service\File\Saver;
 use Aeliot\TodoRegistrarContracts\Context\ContextNodeInterface;
@@ -246,7 +247,7 @@ final class FileParserContextTest extends TestCase
     {
         $statistic = new ProcessStatistic();
         $saver = $this->createMock(Saver::class);
-        $fileHeap = new FileHeap($parsedFile, false, null, $statistic, $saver);
+        $fileHeap = new FileHeap(new CommentNodesBuilder(), $parsedFile, false, null, $statistic, $saver);
 
         return $fileHeap->getCommentNodes();
     }

--- a/tests/Unit/Service/File/ParserTest.php
+++ b/tests/Unit/Service/File/ParserTest.php
@@ -17,6 +17,7 @@ use Aeliot\TodoRegistrar\Dto\FileHeap;
 use Aeliot\TodoRegistrar\Dto\Parsing\CommentNode;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
 use Aeliot\TodoRegistrar\Dto\Tag\TagMetadata;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
 use Aeliot\TodoRegistrar\Service\File\Parser\PhpFileParser;
 use Aeliot\TodoRegistrar\Service\File\Saver;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -71,7 +72,7 @@ CONT,
         $parsedFile = (new PhpFileParser())->parse($this->getMockSplFileInfo($path));
         $statistic = new ProcessStatistic();
         $saver = $this->createMock(Saver::class);
-        $fileHeap = new FileHeap($parsedFile, false, null, $statistic, $saver);
+        $fileHeap = new FileHeap(new CommentNodesBuilder(), $parsedFile, false, null, $statistic, $saver);
 
         return $fileHeap->getCommentNodes();
     }

--- a/tests/Unit/Service/File/YamlFileParserContextTest.php
+++ b/tests/Unit/Service/File/YamlFileParserContextTest.php
@@ -17,6 +17,7 @@ use Aeliot\TodoRegistrar\Dto\FileHeap;
 use Aeliot\TodoRegistrar\Dto\Parsing\CommentNode;
 use Aeliot\TodoRegistrar\Dto\Parsing\ParsedFile;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
 use Aeliot\TodoRegistrar\Service\File\Parser\YamlFileParser;
 use Aeliot\TodoRegistrar\Service\File\Saver;
 use Aeliot\TodoRegistrarContracts\Context\ContextNodeInterface;
@@ -372,7 +373,7 @@ final class YamlFileParserContextTest extends TestCase
     {
         $statistic = new ProcessStatistic();
         $saver = $this->createMock(Saver::class);
-        $fileHeap = new FileHeap($parsedFile, false, null, $statistic, $saver);
+        $fileHeap = new FileHeap(new CommentNodesBuilder(), $parsedFile, false, null, $statistic, $saver);
 
         return $fileHeap->getCommentNodes();
     }

--- a/tests/Unit/Service/FileHeapFactoryTest.php
+++ b/tests/Unit/Service/FileHeapFactoryTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Test\Unit\Service;
+
+use Aeliot\TodoRegistrar\Dto\FileHeap;
+use Aeliot\TodoRegistrar\Exception\LogicException;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
+use Aeliot\TodoRegistrar\Service\Comment\SequentialCommentGlueGateRegistry;
+use Aeliot\TodoRegistrar\Service\File\FileParserInterface;
+use Aeliot\TodoRegistrar\Service\File\FileParserRegistry;
+use Aeliot\TodoRegistrar\Service\File\Parser\PhpFileParser;
+use Aeliot\TodoRegistrar\Service\File\Saver;
+use Aeliot\TodoRegistrar\Service\FileHeapFactory;
+use Aeliot\TodoRegistrar\Test\Unit\Service\Support\ProcessingTestSupport;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[CoversClass(FileHeapFactory::class)]
+#[UsesClass(FileHeap::class)]
+#[UsesClass(CommentNodesBuilder::class)]
+final class FileHeapFactoryTest extends TestCase
+{
+    use ProcessingTestSupport;
+
+    public function testReturnsNullWhenParserIsNotConfigured(): void
+    {
+        $output = new BufferedOutput();
+        $context = $this->createHeapContext($output);
+        $file = new \SplFileInfo(__DIR__ . '/../../fixtures/single_line.php');
+        $fileParserRegistry = $this->createMock(FileParserRegistry::class);
+        $fileParserRegistry->method('findParser')->with('php')->willReturn(null);
+
+        $fileHeap = $this->createFactory($fileParserRegistry)->create($file, $context);
+
+        self::assertNull($fileHeap);
+        self::assertStringContainsString(
+            'There is not configured parser for file:',
+            $output->fetch(),
+        );
+    }
+
+    public function testCreatesFileHeapWhenParserIsAvailable(): void
+    {
+        $context = $this->createHeapContext();
+        $pathname = __DIR__ . '/../../fixtures/single_line.php';
+        $file = new \SplFileInfo($pathname);
+        $fileParserRegistry = $this->createMock(FileParserRegistry::class);
+        $fileParserRegistry->method('findParser')->with('php')->willReturn(new PhpFileParser());
+
+        $fileHeap = $this->createFactory($fileParserRegistry)->create($file, $context);
+
+        self::assertInstanceOf(FileHeap::class, $fileHeap);
+        self::assertNotEmpty($fileHeap->getCommentNodes());
+        self::assertSame(1, $context->statistic->getCountAnalyzedFiles());
+    }
+
+    public function testUsesExtensionAliasFromContext(): void
+    {
+        $context = $this->createHeapContext();
+        $context->extensionAliases = ['module' => 'php'];
+        $path = sys_get_temp_dir() . '/todo-registrar-unit-' . uniqid('', true) . '.module';
+        file_put_contents($path, "<?php\n\n// TODO: aliased extension\n");
+        try {
+            $file = new \SplFileInfo($path);
+            $fileParserRegistry = $this->createMock(FileParserRegistry::class);
+            $fileParserRegistry->expects(self::once())->method('findParser')->with('php')->willReturn(new PhpFileParser());
+
+            $fileHeap = $this->createFactory($fileParserRegistry)->create($file, $context);
+
+            self::assertInstanceOf(FileHeap::class, $fileHeap);
+        } finally {
+            $this->removeFile($path);
+        }
+    }
+
+    public function testThrowsWhenSequentialGlueIsEnabledWithoutGate(): void
+    {
+        $context = $this->createHeapContext();
+        $context->glueSequentialComments = true;
+        $file = new \SplFileInfo(__DIR__ . '/../../fixtures/single_line.php');
+        $fileParserRegistry = $this->createMock(FileParserRegistry::class);
+        $fileParserRegistry->method('findParser')->willReturn($this->createMock(FileParserInterface::class));
+        $glueGateRegistry = $this->createMock(SequentialCommentGlueGateRegistry::class);
+        $glueGateRegistry->method('find')->with('php')->willReturn(null);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Sequential comment glue is enabled but no glue gate is configured');
+
+        (new FileHeapFactory(
+            new CommentNodesBuilder(),
+            $fileParserRegistry,
+            $glueGateRegistry,
+            new Saver(),
+        ))->create($file, $context);
+    }
+
+    private function createFactory(FileParserRegistry $fileParserRegistry): FileHeapFactory
+    {
+        $glueGateRegistry = $this->createMock(SequentialCommentGlueGateRegistry::class);
+
+        return new FileHeapFactory(
+            new CommentNodesBuilder(),
+            $fileParserRegistry,
+            $glueGateRegistry,
+            new Saver(),
+        );
+    }
+}

--- a/tests/Unit/Service/FileProcessorTest.php
+++ b/tests/Unit/Service/FileProcessorTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Test\Unit\Service;
+
+use Aeliot\TodoRegistrar\Dto\FileHeap;
+use Aeliot\TodoRegistrar\Exception\CommentRegistrationException;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
+use Aeliot\TodoRegistrar\Service\FileProcessor;
+use Aeliot\TodoRegistrar\Test\Stub\IncrementalKeyRegistrar;
+use Aeliot\TodoRegistrar\Test\Unit\Service\Support\ProcessingTestSupport;
+use Aeliot\TodoRegistrarContracts\Registrar\RegistrarInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FileProcessor::class)]
+#[UsesClass(FileHeap::class)]
+#[UsesClass(CommentNodesBuilder::class)]
+final class FileProcessorTest extends TestCase
+{
+    use ProcessingTestSupport;
+
+    public function testRegistersTodosAndSavesFile(): void
+    {
+        $path = $this->createTempPhpFile("<?php\n\n// TODO: First task\n// TODO: Second task\n");
+        try {
+            $context = $this->createHeapContext();
+            $fileHeap = $this->createFileHeap($this->parsePhpFile($path), $context);
+            $registrar = new IncrementalKeyRegistrar('KEY');
+
+            (new FileProcessor($this->createCommentExtractor(), $registrar, $this->createTodoBuilder()))
+                ->process($fileHeap, $context);
+
+            $content = (string) file_get_contents($path);
+            self::assertStringContainsString('// TODO: KEY-1 First task', $content);
+            self::assertStringContainsString('// TODO: KEY-2 Second task', $content);
+            self::assertSame(2, $context->statistic->getCountRegisteredTODOs());
+            self::assertSame(2, $fileHeap->getRegistrationCount());
+        } finally {
+            $this->removeFile($path);
+        }
+    }
+
+    public function testSkipsTodoWithExistingKey(): void
+    {
+        $path = $this->createTempPhpFile("<?php\n\n// TODO: PROJ-123 Already registered\n");
+        try {
+            $context = $this->createHeapContext();
+            $fileHeap = $this->createFileHeap($this->parsePhpFile($path), $context);
+            $registrar = $this->createMock(RegistrarInterface::class);
+            $registrar->expects(self::never())->method('register');
+
+            (new FileProcessor($this->createCommentExtractor(), $registrar, $this->createTodoBuilder()))
+                ->process($fileHeap, $context);
+
+            self::assertSame(
+                "<?php\n\n// TODO: PROJ-123 Already registered\n",
+                (string) file_get_contents($path),
+            );
+            self::assertSame(1, $context->statistic->getCountIgnoredTodos());
+            self::assertSame(0, $fileHeap->getRegistrationCount());
+        } finally {
+            $this->removeFile($path);
+        }
+    }
+
+    public function testGlueSameTicketsReusesKeyWithoutSecondRegistrarCall(): void
+    {
+        $path = $this->createTempPhpFile("<?php\n\n// TODO: Same summary\n// TODO: Same summary\n");
+        try {
+            $context = $this->createHeapContext(glueSameTickets: true);
+            $fileHeap = $this->createFileHeap($this->parsePhpFile($path), $context);
+            $registrar = new IncrementalKeyRegistrar('KEY');
+
+            (new FileProcessor($this->createCommentExtractor(), $registrar, $this->createTodoBuilder()))
+                ->process($fileHeap, $context);
+
+            $content = (string) file_get_contents($path);
+            self::assertSame(2, substr_count($content, 'KEY-1'));
+            self::assertStringNotContainsString('KEY-2', $content);
+            self::assertSame(2, $context->statistic->getCountRegisteredTODOs());
+            self::assertSame(1, $context->statistic->getCountGluedTodos());
+            self::assertSame(2, $fileHeap->getRegistrationCount());
+        } finally {
+            $this->removeFile($path);
+        }
+    }
+
+    public function testWrapsRegistrarFailureInCommentRegistrationException(): void
+    {
+        $path = $this->createTempPhpFile("<?php\n\n// TODO: Failing task\n");
+        try {
+            $context = $this->createHeapContext();
+            $fileHeap = $this->createFileHeap($this->parsePhpFile($path), $context);
+            $registrar = $this->createMock(RegistrarInterface::class);
+            $registrar->method('register')->willThrowException(new \RuntimeException('API down'));
+
+            $this->expectException(CommentRegistrationException::class);
+            $this->expectExceptionMessage('Cannot register TODO-comment');
+
+            (new FileProcessor($this->createCommentExtractor(), $registrar, $this->createTodoBuilder()))
+                ->process($fileHeap, $context);
+        } finally {
+            $this->removeFile($path);
+        }
+    }
+}

--- a/tests/Unit/Service/HeapContextFactoryTest.php
+++ b/tests/Unit/Service/HeapContextFactoryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Test\Unit\Service;
+
+use Aeliot\TodoRegistrar\Config;
+use Aeliot\TodoRegistrar\Console\OutputAdapter;
+use Aeliot\TodoRegistrar\Dto\GeneralConfig\ProcessConfig;
+use Aeliot\TodoRegistrar\Dto\HeapContext;
+use Aeliot\TodoRegistrar\Service\File\Finder;
+use Aeliot\TodoRegistrar\Service\HeapContextFactory;
+use Aeliot\TodoRegistrar\Test\Stub\IncrementalRegistrarFactory;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+
+#[CoversClass(HeapContextFactory::class)]
+#[UsesClass(HeapContext::class)]
+#[UsesClass(ProcessConfig::class)]
+final class HeapContextFactoryTest extends TestCase
+{
+    public function testCreatesDefaultsWhenProcessConfigIsUnavailable(): void
+    {
+        $config = $this->createMock(GeneralConfigInterface::class);
+        $output = new OutputAdapter(new NullOutput());
+
+        $context = (new HeapContextFactory())->create($config, $output);
+
+        self::assertSame($output, $context->output);
+        self::assertSame([], $context->extensionAliases);
+        self::assertSame([], $context->hashToKey);
+        self::assertFalse($context->glueSameTickets);
+        self::assertFalse($context->glueSequentialComments);
+        self::assertSame(0, $context->statistic->getCountAnalyzedFiles());
+    }
+
+    public function testMapsProcessConfigOptions(): void
+    {
+        $processConfig = new ProcessConfig();
+        $processConfig->setGlueSameTickets(true);
+        $processConfig->setGlueSequentialComments(true);
+        $processConfig->setExtensionAliases(['module' => 'php', 'yaml' => 'yaml']);
+
+        $config = (new Config())
+            ->setFinder((new Finder())->in(sys_get_temp_dir())->name('*.none'))
+            ->setRegistrar(IncrementalRegistrarFactory::class, ['prefix' => 'KEY'])
+            ->setProcessConfig($processConfig);
+
+        $context = (new HeapContextFactory())->create($config, new OutputAdapter(new NullOutput()));
+
+        self::assertTrue($context->glueSameTickets);
+        self::assertTrue($context->glueSequentialComments);
+        self::assertSame(['module' => 'php', 'yaml' => 'yaml'], $context->extensionAliases);
+    }
+}

--- a/tests/Unit/Service/HeapRunnerTest.php
+++ b/tests/Unit/Service/HeapRunnerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Test\Unit\Service;
+
+use Aeliot\TodoRegistrar\Console\OutputAdapter;
+use Aeliot\TodoRegistrar\Dto\FileHeap;
+use Aeliot\TodoRegistrar\Dto\HeapContext;
+use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
+use Aeliot\TodoRegistrar\Service\FileHeapFactory;
+use Aeliot\TodoRegistrar\Service\FileProcessor;
+use Aeliot\TodoRegistrar\Service\HeapContextFactory;
+use Aeliot\TodoRegistrar\Service\HeapRunner;
+use Aeliot\TodoRegistrar\Test\Unit\Service\Support\ProcessingTestSupport;
+use Aeliot\TodoRegistrarContracts\FinderInterface;
+use Aeliot\TodoRegistrarContracts\GeneralConfig\GeneralConfigInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[CoversClass(HeapRunner::class)]
+final class HeapRunnerTest extends TestCase
+{
+    use ProcessingTestSupport;
+
+    public function testRunProcessesEachDiscoveredFile(): void
+    {
+        $fileA = new \SplFileInfo('/tmp/a.php');
+        $fileB = new \SplFileInfo('/tmp/b.php');
+        $context = $this->createHeapContext();
+        $fileHeap = $this->createMock(FileHeap::class);
+        $fileHeap->method('getRegistrationCount')->willReturn(1);
+        $fileHeap->method('getCommentNodes')->willReturn([]);
+
+        $config = $this->createMock(GeneralConfigInterface::class);
+        $config->method('getFinder')->willReturn($this->createFinder([$fileA, $fileB]));
+
+        $heapContextFactory = $this->createMock(HeapContextFactory::class);
+        $heapContextFactory->method('create')->willReturn($context);
+
+        $fileHeapFactory = $this->createMock(FileHeapFactory::class);
+        $fileHeapFactory->expects(self::exactly(2))->method('create')->willReturn($fileHeap);
+
+        $fileProcessor = $this->createMock(FileProcessor::class);
+        $fileProcessor->expects(self::exactly(2))->method('process');
+
+        $statistic = (new HeapRunner(
+            $config,
+            $fileHeapFactory,
+            $fileProcessor,
+            $heapContextFactory,
+            new OutputAdapter(new BufferedOutput()),
+        ))->run();
+
+        self::assertSame($context->statistic, $statistic);
+    }
+
+    public function testRunSkipsFileWhenFactoryReturnsNull(): void
+    {
+        $file = new \SplFileInfo('/tmp/a.php');
+        $context = $this->createHeapContext();
+
+        $config = $this->createMock(GeneralConfigInterface::class);
+        $config->method('getFinder')->willReturn($this->createFinder([$file]));
+
+        $heapContextFactory = $this->createMock(HeapContextFactory::class);
+        $heapContextFactory->method('create')->willReturn($context);
+
+        $fileHeapFactory = $this->createMock(FileHeapFactory::class);
+        $fileHeapFactory->method('create')->willReturn(null);
+
+        $fileProcessor = $this->createMock(FileProcessor::class);
+        $fileProcessor->expects(self::never())->method('process');
+
+        (new HeapRunner(
+            $config,
+            $fileHeapFactory,
+            $fileProcessor,
+            $heapContextFactory,
+            new OutputAdapter(new BufferedOutput()),
+        ))->run();
+    }
+
+    public function testRunWritesErrorAndRethrowsOnFailure(): void
+    {
+        $file = new \SplFileInfo('/tmp/a.php');
+        $context = $this->createHeapContext();
+        $fileHeap = $this->createMock(FileHeap::class);
+        $output = new BufferedOutput();
+
+        $config = $this->createMock(GeneralConfigInterface::class);
+        $config->method('getFinder')->willReturn($this->createFinder([$file]));
+
+        $heapContextFactory = $this->createMock(HeapContextFactory::class);
+        $heapContextFactory->method('create')->willReturn($context);
+
+        $fileHeapFactory = $this->createMock(FileHeapFactory::class);
+        $fileHeapFactory->method('create')->willReturn($fileHeap);
+
+        $fileProcessor = $this->createMock(FileProcessor::class);
+        $fileProcessor->method('process')->willThrowException(new \RuntimeException('Parse failed'));
+
+        try {
+            (new HeapRunner(
+                $config,
+                $fileHeapFactory,
+                $fileProcessor,
+                $heapContextFactory,
+                new OutputAdapter($output),
+            ))->run();
+            self::fail('Expected RuntimeException was not thrown.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('Parse failed', $exception->getMessage());
+        }
+
+        $outputContent = $output->fetch();
+        self::assertStringContainsString('[ERROR] Parse failed', $outputContent);
+        self::assertStringContainsString('Cannot process file: /tmp/a.php', $outputContent);
+    }
+
+    public function testRunReturnsSharedProcessStatistic(): void
+    {
+        $context = new HeapContext();
+        $context->statistic = new ProcessStatistic();
+        $context->extensionAliases = [];
+        $context->glueSameTickets = false;
+        $context->glueSequentialComments = false;
+        $context->hashToKey = [];
+        $context->output = new OutputAdapter(new BufferedOutput());
+
+        $config = $this->createMock(GeneralConfigInterface::class);
+        $config->method('getFinder')->willReturn($this->createFinder([]));
+
+        $heapContextFactory = $this->createMock(HeapContextFactory::class);
+        $heapContextFactory->method('create')->willReturn($context);
+
+        $statistic = (new HeapRunner(
+            $config,
+            $this->createMock(FileHeapFactory::class),
+            $this->createMock(FileProcessor::class),
+            $heapContextFactory,
+            $context->output,
+        ))->run();
+
+        self::assertSame($context->statistic, $statistic);
+    }
+
+    /**
+     * @param \SplFileInfo[] $files
+     */
+    private function createFinder(array $files): FinderInterface
+    {
+        $finder = $this->createMock(FinderInterface::class);
+        $finder->method('getIterator')->willReturn(new \ArrayIterator($files));
+
+        return $finder;
+    }
+}

--- a/tests/Unit/Service/Support/ProcessingTestSupport.php
+++ b/tests/Unit/Service/Support/ProcessingTestSupport.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Test\Unit\Service\Support;
+
+use Aeliot\TodoRegistrar\Console\OutputAdapter;
+use Aeliot\TodoRegistrar\Dto\FileHeap;
+use Aeliot\TodoRegistrar\Dto\HeapContext;
+use Aeliot\TodoRegistrar\Dto\Parsing\ParsedFile;
+use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
+use Aeliot\TodoRegistrar\Enum\IssueKeyPosition;
+use Aeliot\TodoRegistrar\Service\Comment\Cleaner\PhpCommentCleaner;
+use Aeliot\TodoRegistrar\Service\Comment\Cleaner\YamlCommentCleaner;
+use Aeliot\TodoRegistrar\Service\Comment\CommentCleanerRegistry;
+use Aeliot\TodoRegistrar\Service\Comment\CommentNodesBuilder;
+use Aeliot\TodoRegistrar\Service\Comment\Extractor as CommentExtractor;
+use Aeliot\TodoRegistrar\Service\File\Parser\PhpFileParser;
+use Aeliot\TodoRegistrar\Service\File\Saver;
+use Aeliot\TodoRegistrar\Service\InlineConfig\ArrayFromJsonLikeLexerBuilder;
+use Aeliot\TodoRegistrar\Service\InlineConfig\ExtrasReader;
+use Aeliot\TodoRegistrar\Service\InlineConfig\InlineConfigFactory;
+use Aeliot\TodoRegistrar\Service\Tag\Detector as TagDetector;
+use Aeliot\TodoRegistrar\Service\TodoBuilder;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait ProcessingTestSupport
+{
+    protected function createCommentExtractor(): CommentExtractor
+    {
+        $cleanerRegistry = new CommentCleanerRegistry([
+            new PhpCommentCleaner(),
+            new YamlCommentCleaner(),
+        ]);
+
+        return new CommentExtractor(new TagDetector(['todo', 'fixme'], [':', '-', '>']), $cleanerRegistry);
+    }
+
+    protected function createFileHeap(ParsedFile $parsedFile, HeapContext $context): FileHeap
+    {
+        return new FileHeap(
+            new CommentNodesBuilder(),
+            $parsedFile,
+            $context->glueSequentialComments,
+            null,
+            $context->statistic,
+            new Saver(),
+        );
+    }
+
+    protected function createHeapContext(
+        OutputInterface $output = new NullOutput(),
+        bool $glueSameTickets = false,
+    ): HeapContext {
+        $context = new HeapContext();
+        $context->extensionAliases = [];
+        $context->glueSameTickets = $glueSameTickets;
+        $context->glueSequentialComments = false;
+        $context->hashToKey = [];
+        $context->output = new OutputAdapter($output);
+        $context->statistic = new ProcessStatistic();
+
+        return $context;
+    }
+
+    protected function createTempPhpFile(string $content): string
+    {
+        $path = sys_get_temp_dir() . '/todo-registrar-unit-' . uniqid('', true) . '.php';
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
+    protected function createTodoBuilder(): TodoBuilder
+    {
+        return new TodoBuilder(
+            new InlineConfigFactory(),
+            new ExtrasReader(new ArrayFromJsonLikeLexerBuilder()),
+            IssueKeyPosition::AFTER_SEPARATOR,
+            null,
+            new OutputAdapter(new NullOutput()),
+            false,
+        );
+    }
+
+    protected function parsePhpFile(string $pathname): ParsedFile
+    {
+        return (new PhpFileParser())->parse(new \SplFileInfo($pathname));
+    }
+
+    protected function removeFile(string $path): void
+    {
+        if (is_file($path)) {
+            unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
Previously, processing flow was based on generators. It makes main flow quite simple, but became hell for handling of exceptions. They was 'teleported' to initial generator and their handling was not comfortable.

- It was refactored to imperative flow instead of generators.
- Extracted services to clean up code.
