### PR TITLE
Add list of created issues into summary report

### DIFF
--- a/.cursor/docs/Architecture/ProcessingFlow.md
+++ b/.cursor/docs/Architecture/ProcessingFlow.md
@@ -161,11 +161,21 @@ With `--dry-run`, `FileHeap::recordRegistration()` updates statistics only; `Sav
 
 ## Statistics
 
-**Class:** `ProcessStatistic`
+**Classes:** `ProcessStatistic`, `ProcessMeta`
 
-Tracks per run: analyzed/updated files, comment tokens, ignored/glued/registered TODOs, `newIssues` (registered − glued), per-file registration counts, and `dryRun` flag.
+Tracks per run:
 
-Optional export via [Report](../Feature/Report.md).
+- analyzed/updated files, comment tokens, ignored/glued/registered TODOs
+- `newIssues` (registered − glued)
+- per-file registration counts
+- issue key usage (`key` → `usageCounter`) for each inserted key
+- run metadata (`dryRun` flag) via `ProcessMeta`
+
+`FileProcessor::register()` calls `tickIssueKeyUsage()` on every key injection (new registration or same-ticket glue
+reuse). Ignored TODOs with a pre-existing key in the comment are counted in `ignored` but not added to the issue key
+list.
+
+Optional export via [Report](../Feature/Report.md) (`meta`, `summary`, `issues`, `files`).
 
 ## Processing Loop
 

--- a/.cursor/docs/Feature/Report.md
+++ b/.cursor/docs/Feature/Report.md
@@ -5,8 +5,9 @@ Exports processing statistics after a run. Configured via CLI options only (not 
 ## What It Does
 
 1. `HeapRunner` collects `ProcessStatistic` during file processing
-2. After registration completes, `RegisterCommand` optionally formats and writes the report
-3. Default console summary is always printed; report file is optional
+2. `FileProcessor` records each inserted issue key via `ProcessStatistic::tickIssueKeyUsage()`
+3. After registration completes, `RegisterCommand` optionally formats and writes the report
+4. Default console summary is always printed; report file is optional
 
 ## CLI Options
 
@@ -19,6 +20,9 @@ Exports processing statistics after a run. Configured via CLI options only (not 
 ## Report Structure
 
 ```yaml
+meta:
+  version: 4.0.0      # Application::VERSION
+  dryRun: false       # from --dry-run CLI flag
 summary:
   files:
     analyzed: 10      # files visited
@@ -29,14 +33,22 @@ summary:
     ignored: 5        # skipped (existing key in tag line)
     glued: 2          # same-ticket gluing reuses
     newIssues: 6      # registered - glued (new tracker issues)
-    registered: 8     # comments that would receive a key
+    registered: 8     # comments that received a key (new or reused)
     total: 15         # registered + glued + ignored
+issues:
+  - key: PROJ-1
+    usageCounter: 3   # injected 3 times (e.g. 1 new + 2 glued)
+  - key: PROJ-2
+    usageCounter: 1
 files:
   - path: src/Foo.php
     summary:
       todos:
         registered: 2
 ```
+
+**Issues list:** sorted by `key`. Sum of `usageCounter` equals `summary.todos.registered`. Ignored TODOs (pre-existing
+keys in comments) are not listed.
 
 ## Technical Details
 
@@ -46,5 +58,8 @@ files:
 | Dry-run registrar | `src/Service/Registrar/DryRun/DryRunRegistrar.php` |
 | Dry-run factory | `src/Service/Registrar/DryRun/DryRunRegistrarFactory.php` |
 | Format enum | `src/Enum/ReportFormat.php` |
+| Run metadata | `src/Dto/ProcessMeta.php` |
 | Statistics DTO | `src/Dto/ProcessStatistic.php`, `FileStatistic.php` |
 | CLI wiring | `src/Console/Command/RegisterCommand.php` |
+| Key usage tracking | `src/Service/FileProcessor.php` (`tickIssueKeyUsage` after each injection) |
+| Dry-run flag in meta | `src/Service/HeapContextFactory.php` (`ProcessMeta::setDryRun`) |

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -74,10 +74,10 @@ jobs:
       - name: Update VERSION constant
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          sed -i "s/private const VERSION = '[^']*'/private const VERSION = '${VERSION}'/" src/Console/Application.php
+          sed -i "s/const VERSION = '[^']*'/const VERSION = '${VERSION}'/" src/Console/Application.php
 
           echo "✅ Updated Application.php VERSION constant to: ${VERSION}"
-          grep "private const VERSION" src/Console/Application.php
+          grep "const VERSION" src/Console/Application.php
 
       - name: Configure Git
         run: |

--- a/docs/dry_run.md
+++ b/docs/dry_run.md
@@ -25,7 +25,8 @@ Example:
 todo-registrar register --dry-run --report-format=json --report-path=-
 ```
 
-Console summary uses **Would register** instead of **Registered**. See [Processing report](report.md) for report
+Console summary uses **Would register** instead of **Registered**. The exported report sets `meta.dryRun` to `true`
+and lists dry-run placeholder keys (for example `#dry-run-1`) in `issues`. See [Processing report](report.md) for report
 options and structure.
 
 ## Minimal config with DryRun registrar

--- a/docs/processing_flow.md
+++ b/docs/processing_flow.md
@@ -89,7 +89,9 @@ not needed. See [Processing report](report.md).
 
 ## Step 8: Report (optional)
 
-When `--report-format` is set, run statistics are exported. See [Processing report](report.md).
+When `--report-format` is set, run statistics are exported as JSON or YAML: run metadata (`meta`),
+summary counters (`summary`), inserted issue keys with usage counts (`issues`), and per-file registration
+counts (`files`). See [Processing report](report.md).
 
 ## Error handling
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -1,6 +1,7 @@
 # Processing Report
 
-The script collects information about the processing and can export it to a report file. Use this to integrate with CI pipelines, build custom dashboards, or archive run results.
+The script collects information about the processing and can export it to a report file.
+Use this to integrate with CI pipelines, build custom dashboards, or archive run results.
 
 ## Options
 
@@ -36,24 +37,54 @@ todo-registrar -q --report-format=json --report-path=-
 
 ## Report structure
 
-The report contains summary statistics and per-file details.
+The report contains run metadata, summary statistics, a list of inserted issue keys, and per-file details.
 
-**Summary:**
-- `files.analyzed` — number of analyzed files
-- `files.updated` — number of files with registered TODOs
-- `comments.detected` — total detected comment tokens
-- `todos.ignored` — TODOs ignored (e.g. already had issue key)
-- `todos.glued` — TODOs that reused an issue key via same-ticket gluing
-- `todos.newIssues` — new issues that would be created in the tracker (`registered - glued`)
-- `todos.registered` — TODO comments that would receive an issue key
-- `todos.total` — total TODOs (registered + glued + ignored)
+### Meta
 
-**Files:** list of all analyzed files, each with path and `todos.registered` count (zero for files with no new registrations).
+Run context for archived reports and CI artifacts:
+
+- `meta.version` — application version that produced the report
+- `meta.dryRun` — whether the run used `--dry-run` (no API calls and no source file changes)
+
+### Summary
+
+- `summary.files.analyzed` — number of analyzed files
+- `summary.files.updated` — number of files with at least one registration
+- `summary.comments.detected` — total detected comment tokens
+- `summary.todos.ignored` — TODOs skipped because the comment already contained an issue key
+- `summary.todos.glued` — TODOs that reused an issue key via same-ticket gluing in this run
+- `summary.todos.newIssues` — new issues that would be created in the tracker (`registered - glued`)
+- `summary.todos.registered` — TODO comments that received an issue key in this run (new or reused)
+- `summary.todos.total` — total TODOs (`registered + glued + ignored`)
+
+### Issues
+
+List of issue keys inserted during the run, sorted alphabetically by `key`. Each entry contains:
+
+- `key` — issue key returned by the registrar (or a dry-run placeholder such as `#dry-run-1`)
+- `usageCounter` — how many times this key was injected into TODO comments in this run
+
+TODOs that were ignored because they already had a key are **not** included in `issues`.
+
+When same-ticket gluing reuses a key, `usageCounter` for that key is greater than `1`. The sum of all
+`usageCounter` values equals `summary.todos.registered`.
+
+### Files
+
+List of all analyzed files. Each entry contains:
+
+- `path` — file path
+- `summary.todos.registered` — number of TODO comments that received a key in this file (zero when the file had no
+  registrations)
 
 ## JSON example
 
 ```json
 {
+  "meta": {
+    "version": "4.0.0",
+    "dryRun": true
+  },
   "summary": {
     "files": {
       "analyzed": 42,
@@ -70,6 +101,20 @@ The report contains summary statistics and per-file details.
       "total": 12
     }
   },
+  "issues": [
+    {
+      "key": "PROJ-10",
+      "usageCounter": 1
+    },
+    {
+      "key": "PROJ-11",
+      "usageCounter": 3
+    },
+    {
+      "key": "PROJ-12",
+      "usageCounter": 3
+    }
+  ],
   "files": [
     {
       "path": "src/Service/Foo.php",
@@ -94,6 +139,9 @@ The report contains summary statistics and per-file details.
 ## YAML example
 
 ```yaml
+meta:
+  version: 4.0.0
+  dryRun: true
 summary:
   files:
     analyzed: 42
@@ -106,6 +154,13 @@ summary:
     newIssues: 5
     registered: 7
     total: 12
+issues:
+  - key: PROJ-10
+    usageCounter: 1
+  - key: PROJ-11
+    usageCounter: 3
+  - key: PROJ-12
+    usageCounter: 3
 files:
   - path: src/Service/Foo.php
     summary:

--- a/docs/same_ticket_gluing.md
+++ b/docs/same_ticket_gluing.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-When the same TODO text appears in several places (or several times in one file), this feature reuses a single issue key for all matching comments within one run instead of creating duplicate tickets.
+When the same TODO text appears in several places (or several times in one file), this feature reuses
+a single issue key for all matching comments within one run instead of creating duplicate tickets.
 
 ## Configuration
 
@@ -58,5 +59,7 @@ With `glueSameTickets: false` (default):
 ## Important Notes
 
 - Works with all supported issue trackers
-- Reused keys appear in the processing report under `todos.glued`
-- For detailed config reference, see [Option glueSameTickets](config/general_config_yaml.md#option-gluesametickets) in the general YAML config
+- Reused keys increase `summary.todos.glued` and appear in `issues` with `usageCounter`
+  greater than `1` (or `1` when the key was created and reused in the same run)
+- For detailed config reference, see [Option glueSameTickets](config/general_config_yaml.md#option-gluesametickets)
+  in the general YAML config

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\TaggedContainerInterface;
  */
 final class Application extends SymfonyApplication
 {
-    private const VERSION = '4.0.0';
+    public const VERSION = '4.0.0';
 
     public function __construct(ContainerInterface $container)
     {

--- a/src/Dto/ProcessMeta.php
+++ b/src/Dto/ProcessMeta.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TODO Registrar project.
+ *
+ * (c) Anatoliy Melnikov <5785276@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Aeliot\TodoRegistrar\Dto;
+
+final class ProcessMeta
+{
+    private bool $dryRun = false;
+
+    public function isDryRun(): bool
+    {
+        return $this->dryRun;
+    }
+
+    public function setDryRun(bool $dryRun): void
+    {
+        $this->dryRun = $dryRun;
+    }
+}

--- a/src/Dto/ProcessStatistic.php
+++ b/src/Dto/ProcessStatistic.php
@@ -27,6 +27,11 @@ final class ProcessStatistic
      */
     private array $files = [];
 
+    /**
+     * @var array<string,int>
+     */
+    private array $issueKeyUsages = [];
+
     public function getCountAnalyzedFiles(): int
     {
         return \count($this->files);
@@ -75,6 +80,23 @@ final class ProcessStatistic
         return $this->files[$path];
     }
 
+    /**
+     * @return list<array{key: string, usageCounter: int}>
+     */
+    public function getIssueKeys(): array
+    {
+        ksort($this->issueKeyUsages);
+        $issueKeys = [];
+        foreach ($this->issueKeyUsages as $key => $usageCounter) {
+            $issueKeys[] = [
+                'key' => $key,
+                'usageCounter' => $usageCounter,
+            ];
+        }
+
+        return $issueKeys;
+    }
+
     public function getTodosTotal(): int
     {
         return $this->getCountRegisteredTODOs() + $this->countGluedTodos + $this->countIgnoredTodos;
@@ -98,6 +120,12 @@ final class ProcessStatistic
     public function tickIgnoredTodo(): void
     {
         ++$this->countIgnoredTodos;
+    }
+
+    public function tickIssueKeyUsage(string $key): void
+    {
+        $this->issueKeyUsages[$key] ??= 0;
+        ++$this->issueKeyUsages[$key];
     }
 
     public function tickRegistration(string $path): void

--- a/src/Dto/ProcessStatistic.php
+++ b/src/Dto/ProcessStatistic.php
@@ -32,6 +32,11 @@ final class ProcessStatistic
      */
     private array $issueKeyUsages = [];
 
+    public function __construct(
+        private readonly ProcessMeta $meta = new ProcessMeta(),
+    ) {
+    }
+
     public function getCountAnalyzedFiles(): int
     {
         return \count($this->files);
@@ -95,6 +100,11 @@ final class ProcessStatistic
         }
 
         return $issueKeys;
+    }
+
+    public function getMeta(): ProcessMeta
+    {
+        return $this->meta;
     }
 
     public function getTodosTotal(): int

--- a/src/Service/FileProcessor.php
+++ b/src/Service/FileProcessor.php
@@ -75,6 +75,8 @@ final readonly class FileProcessor
                 $context->output->writeln(\sprintf($message, $key), OutputAdapter::VERBOSITY_VERBOSE);
             }
 
+            $context->statistic->tickIssueKeyUsage($key);
+
             if (!$context->isDryRun) {
                 $todo->injectKey($key);
             }

--- a/src/Service/HeapContextFactory.php
+++ b/src/Service/HeapContextFactory.php
@@ -37,6 +37,8 @@ final readonly class HeapContextFactory
         $context->isDryRun = $isDryRun;
         $context->output = $output;
 
+        $context->statistic->getMeta()->setDryRun($isDryRun);
+
         return $context;
     }
 

--- a/src/Service/Report/ReportBuilder.php
+++ b/src/Service/Report/ReportBuilder.php
@@ -67,6 +67,7 @@ final readonly class ReportBuilder
                     'total' => $statistic->getTodosTotal(),
                 ],
             ],
+            'issues' => $statistic->getIssueKeys(),
             'files' => array_map(
                 static fn (string $path, int $count): array => [
                     'path' => $path,

--- a/src/Service/Report/ReportBuilder.php
+++ b/src/Service/Report/ReportBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Aeliot\TodoRegistrar\Service\Report;
 
+use Aeliot\TodoRegistrar\Console\Application;
 use Aeliot\TodoRegistrar\Dto\ProcessStatistic;
 use Aeliot\TodoRegistrar\Enum\ReportFormat;
 use Aeliot\TodoRegistrar\Exception\LogicException;
@@ -51,6 +52,10 @@ final readonly class ReportBuilder
         $files = $statistic->getFiles();
 
         return [
+            'meta' => [
+                'version' => Application::VERSION,
+                'dryRun' => $statistic->getMeta()->isDryRun(),
+            ],
             'summary' => [
                 'files' => [
                     'analyzed' => $statistic->getCountAnalyzedFiles(),

--- a/tests/Unit/Service/FileProcessorTest.php
+++ b/tests/Unit/Service/FileProcessorTest.php
@@ -47,6 +47,13 @@ final class FileProcessorTest extends TestCase
             self::assertStringContainsString('// TODO: KEY-2 Second task', $content);
             self::assertSame(2, $context->statistic->getCountRegisteredTODOs());
             self::assertSame(2, $fileHeap->getRegistrationCount());
+            self::assertSame(
+                [
+                    ['key' => 'KEY-1', 'usageCounter' => 1],
+                    ['key' => 'KEY-2', 'usageCounter' => 1],
+                ],
+                $context->statistic->getIssueKeys(),
+            );
         } finally {
             $this->removeFile($path);
         }
@@ -92,6 +99,10 @@ final class FileProcessorTest extends TestCase
             self::assertSame(2, $context->statistic->getCountRegisteredTODOs());
             self::assertSame(1, $context->statistic->getCountGluedTodos());
             self::assertSame(2, $fileHeap->getRegistrationCount());
+            self::assertSame(
+                [['key' => 'KEY-1', 'usageCounter' => 2]],
+                $context->statistic->getIssueKeys(),
+            );
         } finally {
             $this->removeFile($path);
         }
@@ -113,6 +124,13 @@ final class FileProcessorTest extends TestCase
             self::assertSame(2, $context->statistic->getCountRegisteredTODOs());
             self::assertSame(2, $context->statistic->getCountNewIssues());
             self::assertSame(2, $fileHeap->getRegistrationCount());
+            self::assertSame(
+                [
+                    ['key' => 'KEY-1', 'usageCounter' => 1],
+                    ['key' => 'KEY-2', 'usageCounter' => 1],
+                ],
+                $context->statistic->getIssueKeys(),
+            );
         } finally {
             $this->removeFile($path);
         }

--- a/tests/Unit/Service/Report/ReportBuilderTest.php
+++ b/tests/Unit/Service/Report/ReportBuilderTest.php
@@ -109,6 +109,26 @@ final class ReportBuilderTest extends TestCase
         self::assertSame(3, $decoded['summary']['todos']['registered']);
     }
 
+    public function testFormatIncludesIssueKeysWithUsageCounters(): void
+    {
+        $statistic = $this->createStatistic(['src/foo.php' => 2], 0, 0, 0);
+        $statistic->tickIssueKeyUsage('PROJ-2');
+        $statistic->tickIssueKeyUsage('PROJ-1');
+        $statistic->tickIssueKeyUsage('PROJ-1');
+
+        $result = $this->reportBuilder->format(ReportFormat::JSON, $statistic);
+
+        $decoded = json_decode($result, true);
+        self::assertArrayHasKey('issues', $decoded);
+        self::assertSame(
+            [
+                ['key' => 'PROJ-1', 'usageCounter' => 2],
+                ['key' => 'PROJ-2', 'usageCounter' => 1],
+            ],
+            $decoded['issues'],
+        );
+    }
+
     /**
      * @param array<string, int> $files path => registration count
      */


### PR DESCRIPTION
Add created `issues` and `meta` date into summary report.
```yaml
meta:
  version: 4.0.0      # Application::VERSION
  dryRun: false       # from --dry-run CLI flag
issues:
  - key: PROJ-1
    usageCounter: 3   # injected 3 times (e.g. 1 new + 2 glued)
  - key: PROJ-2
    usageCounter: 1
```